### PR TITLE
Fix: Shuffle button in now playing becomes hard to tell

### DIFF
--- a/app/src/main/java/com/kabouzeid/gramophone/ui/activities/base/AbsSlidingMusicPanelActivity.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/activities/base/AbsSlidingMusicPanelActivity.java
@@ -722,7 +722,9 @@ public abstract class AbsSlidingMusicPanelActivity extends AbsMusicServiceActivi
     private void updateShuffleState() {
         switch (MusicPlayerRemote.getShuffleMode()) {
             case MusicService.SHUFFLE_MODE_SHUFFLE:
-                int activatedColor = colorPlaybackControls ? lastPlaybackControlsColor : ThemeSingleton.get().positiveColor.getDefaultColor();
+                int activatedColor = colorPlaybackControls
+                        ? getFixedShuffleRepeatButtonColor(lastPlaybackControlsColor)
+                        : ThemeSingleton.get().positiveColor.getDefaultColor();
                 shuffleButton.setImageDrawable(Util.getTintedDrawable(this, R.drawable.ic_shuffle_white_36dp,
                         activatedColor));
                 break;
@@ -745,7 +747,9 @@ public abstract class AbsSlidingMusicPanelActivity extends AbsMusicServiceActivi
     }
 
     private void updateRepeatState() {
-        int activatedColor = colorPlaybackControls ? lastPlaybackControlsColor : ThemeSingleton.get().positiveColor.getDefaultColor();
+        int activatedColor = colorPlaybackControls
+                ? getFixedShuffleRepeatButtonColor(lastPlaybackControlsColor)
+                : ThemeSingleton.get().positiveColor.getDefaultColor();
         switch (MusicPlayerRemote.getRepeatMode()) {
             case MusicService.REPEAT_MODE_ALL:
                 repeatButton.setImageDrawable(Util.getTintedDrawable(this, R.drawable.ic_repeat_white_36dp,
@@ -761,6 +765,18 @@ public abstract class AbsSlidingMusicPanelActivity extends AbsMusicServiceActivi
                         deactivatedColor));
                 break;
         }
+    }
+
+    /**
+     * Checks whether the default color and the activated color are similar. If true, returns a darker
+     * activated color. Else, returns the given color as-is.
+     */
+    private int getFixedShuffleRepeatButtonColor(int activatedColor) {
+        if (ColorUtil.calculateColorDistance(activatedColor,
+                ColorUtil.resolveColor(this, android.R.attr.textColorSecondary))) {
+            return ColorUtil.shiftColor(activatedColor, 0.6f);
+        }
+        return activatedColor;
     }
 
     private void setUpAlbumArtViews() {

--- a/app/src/main/java/com/kabouzeid/gramophone/util/ColorUtil.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/util/ColorUtil.java
@@ -137,4 +137,17 @@ public class ColorUtil {
         }
         return backgroundColor;
     }
+
+    /**
+     * Calculates the distance of two colors in 3D Space.
+     *
+     * Taken from http://stackoverflow.com/a/1725535/984061
+     */
+    public static boolean calculateColorDistance(int color1, int color2) {
+        double red = Math.pow(Math.abs(Color.red(color2) - Color.red(color1)), 2);
+        double green = Math.pow(Math.abs(Color.green(color2) - Color.green(color1)), 2);
+        double blue = Math.pow(Math.abs(Color.blue(color2) - Color.blue(color1)), 2);
+        double distance = red + green + blue;
+        return distance < 55000;
+    }
 }


### PR DESCRIPTION
We check for the difference between the default and the activated colors. If the difference value is less than 55000, the activated color is shifted up.

Here is a preview of what happens: http://puu.sh/kkCK6/f38f95b6b7.mp4
The repeat button is without the fix and the shuffle button is with it.

It's probably still not perfect, but better I'd say. Also, not much cluttering has been added I'd say. :)
