### PR TITLE
fix: tab layout #90

### DIFF
--- a/app/src/main/res/layout/fragment_library.xml
+++ b/app/src/main/res/layout/fragment_library.xml
@@ -50,8 +50,9 @@
                 android:id="@+id/tabs"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/tab_height"
-                app:tabContentStart="72dp"
-                app:tabMode="scrollable" />
+                app:tabGravity="fill"
+                app:tabMaxWidth="0dp"
+                app:tabMode="fixed" />
 
         </android.support.design.widget.AppBarLayout>
 


### PR DESCRIPTION
The gap was intentionally made with a `72dp` padding. This does not look very well, so I removed it.
Removing it caused the tabs to shift left, therefore, a `tabMaxWidth` was used to fill the width.