### PR TITLE
Bring up the Now Playing panel on tapping notification

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,7 +20,8 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Phonograph.Light"
         tools:ignore="UnusedAttribute">
-        <activity android:name=".ui.activities.MainActivity">
+        <activity android:name=".ui.activities.MainActivity"
+            android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <action android:name="android.intent.action.MUSIC_PLAYER" />

--- a/app/src/main/java/com/kabouzeid/gramophone/service/MusicService.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/service/MusicService.java
@@ -96,6 +96,7 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
     public static final String SAVED_POSITION_IN_TRACK = "POSITION_IN_TRACK";
     public static final String SAVED_SHUFFLE_MODE = "SHUFFLE_MODE";
     public static final String SAVED_REPEAT_MODE = "REPEAT_MODE";
+    public static final String OPEN_NOW_PLAYING = "OPEN_NOW_PLAYING";
 
     public static final int RELEASE_WAKELOCK = 0;
     public static final int TRACK_ENDED = 1;

--- a/app/src/main/java/com/kabouzeid/gramophone/service/notification/PlayingNotificationImpl.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/service/notification/PlayingNotificationImpl.java
@@ -80,8 +80,8 @@ public class PlayingNotificationImpl implements PlayingNotification {
         linkButtons(notificationLayout, notificationLayoutBig);
 
         Intent action = new Intent(service, MainActivity.class);
-        action.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
-        PendingIntent openAppPendingIntent = PendingIntent.getActivity(service, 0, action, 0);
+        action.putExtra(MusicService.OPEN_NOW_PLAYING, true);
+        final PendingIntent openAppPendingIntent = PendingIntent.getActivity(service, 0, action, PendingIntent.FLAG_UPDATE_CURRENT);
 
         final Notification notification = new NotificationCompat.Builder(service)
                 .setSmallIcon(R.drawable.ic_notification)

--- a/app/src/main/java/com/kabouzeid/gramophone/service/notification/PlayingNotificationImpl24.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/service/notification/PlayingNotificationImpl24.java
@@ -68,8 +68,8 @@ public class PlayingNotificationImpl24 implements PlayingNotification {
                 ? R.drawable.ic_pause_white_24dp : R.drawable.ic_play_arrow_white_24dp;
 
         Intent action = new Intent(service, MainActivity.class);
-        action.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
-        final PendingIntent clickIntent = PendingIntent.getActivity(service, 0, action, 0);
+        action.putExtra(MusicService.OPEN_NOW_PLAYING, true);
+        final PendingIntent clickIntent = PendingIntent.getActivity(service, 0, action, PendingIntent.FLAG_UPDATE_CURRENT);
 
         final ComponentName serviceName = new ComponentName(service, MusicService.class);
         Intent intent = new Intent(MusicService.ACTION_QUIT);

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/activities/MainActivity.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/activities/MainActivity.java
@@ -106,6 +106,9 @@ public class MainActivity extends AbsSlidingMusicPanelActivity {
         if (!checkShowIntro()) {
             checkShowChangelog();
         }
+
+        //manually call onNewIntent() to expand panel if notification was tapped while app is closed
+        onNewIntent(getIntent());
     }
 
     private void setMusicChooser(int key) {
@@ -390,5 +393,21 @@ public class MainActivity extends AbsSlidingMusicPanelActivity {
 
     public interface MainActivityFragmentCallbacks {
         boolean handleBackPress();
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        if (intent.getBooleanExtra(MusicService.OPEN_NOW_PLAYING, false)) {
+            //not using a Handler causes a crash when coming here from MainActivity.onCreate()
+            new Handler().postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    if (getPanelState() == SlidingUpPanelLayout.PanelState.COLLAPSED) {
+                        expandPanel();
+                    }
+                }
+            }, 750);
+        }
     }
 }


### PR DESCRIPTION
Addresses issue #93 

From the discussion on #92:
> There's a slight hack there, playerControlFragment.onShow() throws NPE if MainActivity is not already created (i.e. the notification is tapped when the app itself is closed), unless I put the call to expandPanel() in Handler().postDelayed(). Curiously enough, even a delay of 0 works just fine, but I put in a delay of 750ms, to give time for the MainActivity to draw first (which allows for a smooth sliding up of the panel), and just to be sure there's no crashes on very slow devices)

Tested on Android 7.1.1 (AOSP Extended custom ROM), Android 6.0.1 (MIUI 8)