### PR TITLE
Add MediaButtonIntentReceiver back into AndroidManifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -98,6 +98,12 @@
             android:name=".service.MusicService"
             android:enabled="true" />
 
+        <receiver android:name=".service.MediaButtonIntentReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.MEDIA_BUTTON" />
+            </intent-filter>
+        </receiver>
+        
         <meta-data
             android:name="com.crashlytics.ApiKey"
             android:value="b23725bd3d266aa65c5a3dd1816b2f801524a189" />


### PR DESCRIPTION
Removing it caused the inability to start playback if the ui was not in
foreground