### PR TITLE
Add lyrics editor in SongTagEditorActivity

### DIFF
--- a/app/src/main/java/com/kabouzeid/gramophone/ui/activities/tageditor/AbsTagEditorActivity.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/activities/tageditor/AbsTagEditorActivity.java
@@ -508,6 +508,15 @@ public abstract class AbsTagEditorActivity extends AbsBaseActivity {
     }
 
     @Nullable
+    protected String getLyrics() {
+        try {
+            return getAudioFile(songPaths.get(0)).getTagOrCreateAndSetDefault().getFirst(FieldKey.LYRICS);
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    @Nullable
     protected Bitmap getAlbumArt() {
         try {
             Artwork artworkTag = getAudioFile(songPaths.get(0)).getTagOrCreateAndSetDefault().getFirstArtwork();

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/activities/tageditor/SongTagEditorActivity.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/activities/tageditor/SongTagEditorActivity.java
@@ -37,6 +37,8 @@ public class SongTagEditorActivity extends AbsTagEditorActivity implements TextW
     EditText year;
     @BindView(R.id.image_text)
     EditText trackNumber;
+    @BindView(R.id.lyrics)
+    EditText lyrics;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -58,6 +60,7 @@ public class SongTagEditorActivity extends AbsTagEditorActivity implements TextW
         genre.addTextChangedListener(this);
         year.addTextChangedListener(this);
         trackNumber.addTextChangedListener(this);
+        lyrics.addTextChangedListener(this);
     }
 
     private void fillViewsWithFileTags() {
@@ -67,6 +70,7 @@ public class SongTagEditorActivity extends AbsTagEditorActivity implements TextW
         genre.setText(getGenreName());
         year.setText(getSongYear());
         trackNumber.setText(getTrackNumber());
+        lyrics.setText(getLyrics());
     }
 
     @Override
@@ -98,6 +102,7 @@ public class SongTagEditorActivity extends AbsTagEditorActivity implements TextW
         fieldKeyValueMap.put(FieldKey.GENRE, genre.getText().toString());
         fieldKeyValueMap.put(FieldKey.YEAR, year.getText().toString());
         fieldKeyValueMap.put(FieldKey.TRACK, trackNumber.getText().toString());
+        fieldKeyValueMap.put(FieldKey.LYRICS, lyrics.getText().toString());
         writeValuesToFiles(fieldKeyValueMap, null);
     }
 

--- a/app/src/main/res/layout/activity_song_tag_editor.xml
+++ b/app/src/main/res/layout/activity_song_tag_editor.xml
@@ -157,6 +157,23 @@
 
                 </android.support.design.widget.TextInputLayout>
 
+                <android.support.design.widget.TextInputLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content">
+
+                    <EditText
+                        android:id="@+id/lyrics"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:fontFamily="sans-serif"
+                        android:gravity="center_vertical"
+                        android:hint="@string/lyrics"
+                        android:inputType="textMultiLine"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Title" />
+
+                </android.support.design.widget.TextInputLayout>
+
             </LinearLayout>
 
         </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,6 +48,7 @@
     <string name="year">Year</string>
     <string name="track">Track</string>
     <string name="track_hint">"Track (2 for track 2 or 3004 for CD3 track 4)"</string>
+    <string name="lyrics">Lyrics</string>
     <string name="album_or_artist_empty">The title or artist is empty.</string>
     <string name="saving_changes">Saving changes</string>
     <string name="saving_to_file">Saving to file…</string>


### PR DESCRIPTION
Allow to edit lyrics on the tag editor activity. I've tested it with .mp3 and .m4a files