### PR TITLE
Fix: can't play media files from file browser

### DIFF
--- a/app/src/main/java/com/kabouzeid/gramophone/helper/MusicPlayerRemote.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/helper/MusicPlayerRemote.java
@@ -1,12 +1,17 @@
 package com.kabouzeid.gramophone.helper;
 
+import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.ComponentName;
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.ContextWrapper;
 import android.content.Intent;
 import android.content.ServiceConnection;
+import android.net.Uri;
+import android.os.Build;
 import android.os.IBinder;
+import android.provider.DocumentsContract;
 import android.provider.MediaStore;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -17,6 +22,7 @@ import com.kabouzeid.gramophone.loader.SongLoader;
 import com.kabouzeid.gramophone.model.Song;
 import com.kabouzeid.gramophone.service.MusicService;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Random;
 import java.util.WeakHashMap;
@@ -374,19 +380,43 @@ public class MusicPlayerRemote {
         return -1;
     }
 
-    public static void playFile(String path) {
+    public static void playFromUri(Uri uri) {
         if (musicService != null) {
-            ArrayList<Song> songs = SongLoader.getSongs(SongLoader.makeSongCursor(
-                    musicService,
-                    MediaStore.Audio.AudioColumns.DATA + "=?",
-                    new String[]{path}
-            ));
-            if (!songs.isEmpty()) {
+            ArrayList<Song> songs = null;
+            if (uri.getScheme() != null && uri.getAuthority() != null) {
+                if (uri.getScheme().equals(ContentResolver.SCHEME_CONTENT)) {
+                    String songId = null;
+                    if (uri.getAuthority().equals("com.android.providers.media.documents")) {
+                        songId = getSongIdFromMediaProvider(uri);
+                    } else if (uri.getAuthority().equals("media")) {
+                        songId = uri.getLastPathSegment();
+                    }
+                    if (songId != null) {
+                        songs = SongLoader.getSongs(SongLoader.makeSongCursor(
+                                musicService,
+                                MediaStore.Audio.AudioColumns._ID + "=?",
+                                new String[]{songId}
+                        ));
+                    }
+                }
+            }
+            if (songs == null && uri.getPath() != null) {
+                songs = SongLoader.getSongs(SongLoader.makeSongCursor(
+                        musicService,
+                        MediaStore.Audio.AudioColumns.DATA + "=?",
+                        new String[]{new File(uri.getPath()).getAbsolutePath()}
+                ));
+            }
+            if (songs != null && !songs.isEmpty()) {
                 openQueue(songs, 0, true);
             } else {
                 //TODO the file is not listed in the media store
             }
         }
+    }
+    @TargetApi(Build.VERSION_CODES.KITKAT)
+    private static String getSongIdFromMediaProvider(Uri uri) {
+        return DocumentsContract.getDocumentId(uri).split(":")[1];
     }
 
     public static boolean isServiceConnected() {

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/activities/MainActivity.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/activities/MainActivity.java
@@ -46,7 +46,6 @@ import com.kabouzeid.gramophone.util.PreferenceUtil;
 import com.kabouzeid.gramophone.util.Util;
 import com.sothree.slidinguppanel.SlidingUpPanelLayout;
 
-import java.io.File;
 import java.util.ArrayList;
 
 import butterknife.BindView;
@@ -299,7 +298,7 @@ public class MainActivity extends AbsSlidingMusicPanelActivity {
         }
 
         if (uri != null && uri.toString().length() > 0) {
-            MusicPlayerRemote.playFile(new File(uri.getPath()).getAbsolutePath());
+            MusicPlayerRemote.playFromUri(uri);
             handled = true;
         } else if (MediaStore.Audio.Playlists.CONTENT_TYPE.equals(mimeType)) {
             final int id = (int) parseIdFromIntent(intent, "playlistId", "playlist");


### PR DESCRIPTION
Address issue #100

When media file is selected from various file browers, the uri sent to app might be different scheme like file or content. Fix is to query the media file based on different scheme.

Tested on Android 7.1.1 from ASUS File Manager, Amaze and Android Download.
