### PR TITLE
Fix: App shortcut: Crash and resume when empty (issue #111 and issue #112)

### DIFF
--- a/app/src/main/java/com/kabouzeid/gramophone/appshortcuts/AppShortcutLauncherActivity.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/appshortcuts/AppShortcutLauncherActivity.java
@@ -8,15 +8,14 @@ import android.support.annotation.IntDef;
 import com.kabouzeid.gramophone.appshortcuts.shortcuttype.LastAddedShortcutType;
 import com.kabouzeid.gramophone.appshortcuts.shortcuttype.ShuffleAllShortcutType;
 import com.kabouzeid.gramophone.appshortcuts.shortcuttype.TopTracksShortcutType;
-import com.kabouzeid.gramophone.loader.LastAddedLoader;
-import com.kabouzeid.gramophone.loader.SongLoader;
-import com.kabouzeid.gramophone.loader.TopAndRecentlyPlayedTracksLoader;
-import com.kabouzeid.gramophone.model.Song;
+import com.kabouzeid.gramophone.model.Playlist;
+import com.kabouzeid.gramophone.model.smartplaylist.LastAddedPlaylist;
+import com.kabouzeid.gramophone.model.smartplaylist.MyTopTracksPlaylist;
+import com.kabouzeid.gramophone.model.smartplaylist.ShuffleAllPlaylist;
 import com.kabouzeid.gramophone.service.MusicService;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import java.util.ArrayList;
 
 /**
  * @author Adrian Campos
@@ -46,18 +45,18 @@ public class AppShortcutLauncherActivity extends Activity {
 
         switch (shortcutType) {
             case SHORTCUT_TYPE_SHUFFLE_ALL:
-                startServiceWithSongs(MusicService.SHUFFLE_MODE_SHUFFLE,
-                        SongLoader.getAllSongs(getApplicationContext()));
+                startServiceWithPlaylist(MusicService.SHUFFLE_MODE_SHUFFLE,
+                        new ShuffleAllPlaylist(getApplicationContext()));
                 DynamicShortcutManager.reportShortcutUsed(this, ShuffleAllShortcutType.getId());
                 break;
             case SHORTCUT_TYPE_TOP_TRACKS:
-                startServiceWithSongs(MusicService.SHUFFLE_MODE_NONE,
-                        TopAndRecentlyPlayedTracksLoader.getTopTracks(getApplicationContext()));
+                startServiceWithPlaylist(MusicService.SHUFFLE_MODE_NONE,
+                        new MyTopTracksPlaylist(getApplicationContext()));
                 DynamicShortcutManager.reportShortcutUsed(this, TopTracksShortcutType.getId());
                 break;
             case SHORTCUT_TYPE_LAST_ADDED:
-                startServiceWithSongs(MusicService.SHUFFLE_MODE_NONE,
-                        LastAddedLoader.getLastAddedSongs(getApplicationContext()));
+                startServiceWithPlaylist(MusicService.SHUFFLE_MODE_NONE,
+                        new LastAddedPlaylist(getApplicationContext()));
                 DynamicShortcutManager.reportShortcutUsed(this, LastAddedShortcutType.getId());
                 break;
         }
@@ -65,12 +64,12 @@ public class AppShortcutLauncherActivity extends Activity {
         finish();
     }
 
-    private void startServiceWithSongs(int shuffleMode, ArrayList<Song> songs) {
+    private void startServiceWithPlaylist(int shuffleMode, Playlist playlist) {
         Intent intent = new Intent(this, MusicService.class);
-        intent.setAction(MusicService.ACTION_PLAY);
+        intent.setAction(MusicService.ACTION_PLAY_PLAYLIST);
 
         Bundle bundle = new Bundle();
-        bundle.putParcelableArrayList(MusicService.INTENT_EXTRA_SONGS, songs);
+        bundle.putParcelable(MusicService.INTENT_EXTRA_PLAYLIST, playlist);
         bundle.putInt(MusicService.INTENT_EXTRA_SHUFFLE_MODE, shuffleMode);
 
         intent.putExtras(bundle);

--- a/app/src/main/java/com/kabouzeid/gramophone/model/smartplaylist/ShuffleAllPlaylist.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/model/smartplaylist/ShuffleAllPlaylist.java
@@ -1,0 +1,54 @@
+package com.kabouzeid.gramophone.model.smartplaylist;
+
+import android.content.Context;
+import android.os.Parcel;
+import android.support.annotation.NonNull;
+
+import com.kabouzeid.gramophone.R;
+import com.kabouzeid.gramophone.loader.SongLoader;
+import com.kabouzeid.gramophone.model.Song;
+
+import java.util.ArrayList;
+
+public class ShuffleAllPlaylist extends AbsSmartPlaylist {
+
+    public ShuffleAllPlaylist(@NonNull Context context) {
+        super(context.getString(R.string.shuffle_all), R.drawable.ic_shuffle_white_24dp);
+    }
+
+    @NonNull
+    @Override
+    public ArrayList<Song> getSongs(@NonNull Context context) {
+        return SongLoader.getAllSongs(context);
+    }
+
+    @Override
+    public void clear(@NonNull Context context) {
+        //Can't clear all songs. Don't do anything here?
+    }
+
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        super.writeToParcel(dest, flags);
+    }
+
+    protected ShuffleAllPlaylist(Parcel in) {
+        super(in);
+    }
+
+    public static final Creator<ShuffleAllPlaylist> CREATOR = new Creator<ShuffleAllPlaylist>() {
+        public ShuffleAllPlaylist createFromParcel(Parcel source) {
+            return new ShuffleAllPlaylist(source);
+        }
+
+        public ShuffleAllPlaylist[] newArray(int size) {
+            return new ShuffleAllPlaylist[size];
+        }
+    };
+}

--- a/app/src/main/java/com/kabouzeid/gramophone/service/MusicService.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/service/MusicService.java
@@ -298,7 +298,7 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
                         break;
                     case ACTION_PLAY:
                         ArrayList<Song> songs = intent.getParcelableArrayListExtra(INTENT_EXTRA_SONGS);
-                        if (songs != null) {
+                        if (songs != null && !songs.isEmpty()) {
                             int shuffleMode = intent.getIntExtra(INTENT_EXTRA_SHUFFLE_MODE, getShuffleMode());
                             if (intent.hasExtra(INTENT_EXTRA_SHUFFLE_MODE) && intent.getIntExtra(INTENT_EXTRA_SHUFFLE_MODE, 0) == SHUFFLE_MODE_SHUFFLE) {
                                 int startPosition = 0;
@@ -310,8 +310,10 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
                             } else {
                                 openQueue(songs, 0, false);
                             }
+                            play();
+                        } else {
+                            Toast.makeText(getApplicationContext(), R.string.no_songs_in_playlist, Toast.LENGTH_LONG).show();
                         }
-                        play();
                         break;
                     case ACTION_REWIND:
                         back(true);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -288,4 +288,6 @@
     
     <string name="app_shortcut_last_added_long">@string/last_added</string>
     <string name="app_shortcut_last_added_short">@string/last_added</string>
+
+    <string name="no_songs_in_playlist">No songs in playlist</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -181,6 +181,7 @@
     <string name="favorites">Favorites</string>
     <string name="last_added">Last added</string>
     <string name="history">History</string>
+    <string name="shuffle_all">Shuffle All</string>
     <string name="my_top_tracks">My top tracks</string>
     <string name="remove_cover">Remove cover</string>
     <string name="download_from_last_fm">Download from Last.fm</string>


### PR DESCRIPTION
Fixes issue #111 .

```play()``` was still called even if the playlist was empty.

This adds a check for that and shows a toast if it is.

Thanks @arkon!