### PR TITLE
Dynamic size status bars

### DIFF
--- a/app/src/main/java/com/kabouzeid/gramophone/ui/activities/AboutActivity.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/activities/AboutActivity.java
@@ -21,6 +21,7 @@ import com.kabouzeid.gramophone.dialogs.DonationsDialog;
 import com.kabouzeid.gramophone.ui.activities.base.AbsBaseActivity;
 import com.kabouzeid.gramophone.ui.activities.bugreport.BugReportActivity;
 import com.kabouzeid.gramophone.ui.activities.intro.AppIntroActivity;
+import com.kabouzeid.gramophone.util.ViewUtil;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -91,6 +92,8 @@ public class AboutActivity extends AbsBaseActivity implements View.OnClickListen
     AppCompatButton maartenCorpelGooglePlus;
     @BindView(R.id.aleksandar_tesic_google_plus)
     AppCompatButton aleksandarTesicGooglePlus;
+    @BindView(R.id.status_bar)
+    View statusBar;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -102,6 +105,7 @@ public class AboutActivity extends AbsBaseActivity implements View.OnClickListen
         setStatusbarColorAuto();
         setNavigationbarColorAuto();
         setTaskDescriptionColorAuto();
+        ViewUtil.setStatusBarHeight(this, statusBar);
 
         setUpViews();
     }

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/activities/AlbumDetailActivity.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/activities/AlbumDetailActivity.java
@@ -44,6 +44,7 @@ import com.kabouzeid.gramophone.ui.activities.tageditor.AlbumTagEditorActivity;
 import com.kabouzeid.gramophone.util.NavigationUtil;
 import com.kabouzeid.gramophone.util.PhonographColorUtil;
 import com.kabouzeid.gramophone.util.Util;
+import com.kabouzeid.gramophone.util.ViewUtil;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -71,6 +72,8 @@ public class AlbumDetailActivity extends AbsSlidingMusicPanelActivity implements
     TextView albumTitleView;
     @BindView(R.id.list_background)
     View songsBackgroundView;
+    @BindView(R.id.status_bar)
+    View statusBar;
 
     private AlbumSongAdapter adapter;
 
@@ -92,6 +95,7 @@ public class AlbumDetailActivity extends AbsSlidingMusicPanelActivity implements
         setUpObservableListViewParams();
         setUpToolBar();
         setUpViews();
+        ViewUtil.setStatusBarHeight(this, statusBar);
 
         getSupportLoaderManager().initLoader(LOADER_ID, getIntent().getExtras(), this);
     }

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/activities/ArtistDetailActivity.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/activities/ArtistDetailActivity.java
@@ -54,6 +54,7 @@ import com.kabouzeid.gramophone.util.ArtistSignatureUtil;
 import com.kabouzeid.gramophone.util.NavigationUtil;
 import com.kabouzeid.gramophone.util.PhonographColorUtil;
 import com.kabouzeid.gramophone.util.Util;
+import com.kabouzeid.gramophone.util.ViewUtil;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -81,6 +82,8 @@ public class ArtistDetailActivity extends AbsSlidingMusicPanelActivity implement
     TextView artistName;
     @BindView(R.id.toolbar)
     Toolbar toolbar;
+    @BindView(R.id.status_bar)
+    View statusBar;
 
     View songListHeader;
     RecyclerView albumRecyclerView;
@@ -114,6 +117,7 @@ public class ArtistDetailActivity extends AbsSlidingMusicPanelActivity implement
         setUpObservableListViewParams();
         setUpViews();
         setUpToolbar();
+        ViewUtil.setStatusBarHeight(this, statusBar);
 
         getSupportLoaderManager().initLoader(LOADER_ID, getIntent().getExtras(), this);
     }

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/activities/PlaylistDetailActivity.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/activities/PlaylistDetailActivity.java
@@ -37,6 +37,7 @@ import com.kabouzeid.gramophone.ui.activities.base.AbsSlidingMusicPanelActivity;
 import com.kabouzeid.gramophone.util.NavigationUtil;
 import com.kabouzeid.gramophone.util.PhonographColorUtil;
 import com.kabouzeid.gramophone.util.PlaylistsUtil;
+import com.kabouzeid.gramophone.util.ViewUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -59,6 +60,8 @@ public class PlaylistDetailActivity extends AbsSlidingMusicPanelActivity impleme
     Toolbar toolbar;
     @BindView(android.R.id.empty)
     TextView empty;
+    @BindView(R.id.status_bar)
+    View statusBar;
 
     private Playlist playlist;
 
@@ -77,6 +80,7 @@ public class PlaylistDetailActivity extends AbsSlidingMusicPanelActivity impleme
         setStatusbarColorAuto();
         setNavigationbarColorAuto();
         setTaskDescriptionColorAuto();
+        ViewUtil.setStatusBarHeight(this, statusBar);
 
         playlist = getIntent().getExtras().getParcelable(EXTRA_PLAYLIST);
 

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/activities/SearchActivity.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/activities/SearchActivity.java
@@ -27,6 +27,7 @@ import com.kabouzeid.gramophone.loader.SongLoader;
 import com.kabouzeid.gramophone.misc.WrappedAsyncTaskLoader;
 import com.kabouzeid.gramophone.ui.activities.base.AbsMusicServiceActivity;
 import com.kabouzeid.gramophone.util.Util;
+import com.kabouzeid.gramophone.util.ViewUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -46,6 +47,8 @@ public class SearchActivity extends AbsMusicServiceActivity implements SearchVie
     Toolbar toolbar;
     @BindView(android.R.id.empty)
     TextView empty;
+    @BindView(R.id.status_bar)
+    View statusBar;
 
     SearchView searchView;
 
@@ -62,6 +65,7 @@ public class SearchActivity extends AbsMusicServiceActivity implements SearchVie
         setStatusbarColorAuto();
         setNavigationbarColorAuto();
         setTaskDescriptionColorAuto();
+        ViewUtil.setStatusBarHeight(this, statusBar);
 
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
         adapter = new SearchAdapter(this, Collections.emptyList());

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/activities/SettingsActivity.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/activities/SettingsActivity.java
@@ -30,6 +30,7 @@ import com.kabouzeid.gramophone.preferences.NowPlayingScreenPreferenceDialog;
 import com.kabouzeid.gramophone.ui.activities.base.AbsBaseActivity;
 import com.kabouzeid.gramophone.util.NavigationUtil;
 import com.kabouzeid.gramophone.util.PreferenceUtil;
+import com.kabouzeid.gramophone.util.ViewUtil;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -39,6 +40,8 @@ public class SettingsActivity extends AbsBaseActivity implements ColorChooserDia
 
     @BindView(R.id.toolbar)
     Toolbar toolbar;
+    @BindView(R.id.status_bar)
+    View statusBar;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -50,6 +53,7 @@ public class SettingsActivity extends AbsBaseActivity implements ColorChooserDia
         setStatusbarColorAuto();
         setNavigationbarColorAuto();
         setTaskDescriptionColorAuto();
+        ViewUtil.setStatusBarHeight(this, statusBar);
 
         toolbar.setBackgroundColor(ThemeStore.primaryColor(this));
         setSupportActionBar(toolbar);

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/folders/FoldersFragment.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/folders/FoldersFragment.java
@@ -92,6 +92,8 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
     AppBarLayout appbar;
     @BindView(R.id.recycler_view)
     FastScrollRecyclerView recyclerView;
+    @BindView(R.id.status_bar)
+    View statusBar;
 
     private SongFileAdapter adapter;
     private MaterialCab cab;
@@ -168,6 +170,7 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
         setUpBreadCrumbs();
         setUpRecyclerView();
         setUpAdapter();
+        ViewUtil.setStatusBarHeight(getActivity(), statusBar);
     }
 
     private void setUpAppbarColor() {

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/LibraryFragment.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/LibraryFragment.java
@@ -57,6 +57,8 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
     AppBarLayout appbar;
     @BindView(R.id.pager)
     ViewPager pager;
+    @BindView(R.id.status_bar)
+    View statusBar;
 
     private MusicLibraryPagerAdapter pagerAdapter;
     private MaterialCab cab;
@@ -90,6 +92,7 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
 
         setUpToolbar();
         setUpViewPager();
+        setUpStatusBar();
     }
 
     private void setUpToolbar() {
@@ -120,6 +123,12 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
         pager.setCurrentItem(startPosition);
         PreferenceUtil.getInstance(getActivity()).setLastPage(startPosition); // just in case
         pager.addOnPageChangeListener(this);
+    }
+
+    private void setUpStatusBar() {
+        ViewGroup.LayoutParams layoutParams = statusBar.getLayoutParams();
+        layoutParams.height = Util.getStatusBarHeight(getMainActivity());
+        statusBar.setLayoutParams(layoutParams);
     }
 
     public Fragment getCurrentFragment() {

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/LibraryFragment.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/LibraryFragment.java
@@ -39,6 +39,7 @@ import com.kabouzeid.gramophone.util.NavigationUtil;
 import com.kabouzeid.gramophone.util.PhonographColorUtil;
 import com.kabouzeid.gramophone.util.PreferenceUtil;
 import com.kabouzeid.gramophone.util.Util;
+import com.kabouzeid.gramophone.util.ViewUtil;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -93,6 +94,7 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
         setUpToolbar();
         setUpViewPager();
         setUpStatusBar();
+        ViewUtil.setStatusBarHeight(getActivity(), statusBar);
     }
 
     private void setUpToolbar() {

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/player/card/CardPlayerFragment.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/player/card/CardPlayerFragment.java
@@ -232,6 +232,10 @@ public class CardPlayerFragment extends AbsPlayerFragment implements PlayerAlbum
             }
         });
         toolbar.setOnMenuItemClickListener(this);
+
+        ViewGroup.MarginLayoutParams lp = (ViewGroup.MarginLayoutParams)toolbar.getLayoutParams();
+        lp.setMargins(lp.leftMargin, Util.getStatusBarHeight(getActivity()), lp.rightMargin, lp.bottomMargin);
+        toolbar.requestLayout();
     }
 
     @Override

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/player/card/CardPlayerFragment.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/player/card/CardPlayerFragment.java
@@ -119,6 +119,12 @@ public class CardPlayerFragment extends AbsPlayerFragment implements PlayerAlbum
         setUpPlayerToolbar();
         setUpSubFragments();
 
+        // portrait view doesn't have a statusBar, so can't bind it up top as will throw an exception.
+        View statusBar = view.findViewById(R.id.status_bar);
+        if (statusBar != null) {
+            ViewUtil.setStatusBarHeight(getActivity(), statusBar);
+        }
+
         setUpRecyclerView();
 
         slidingUpPanelLayout.addPanelSlideListener(this);
@@ -232,10 +238,6 @@ public class CardPlayerFragment extends AbsPlayerFragment implements PlayerAlbum
             }
         });
         toolbar.setOnMenuItemClickListener(this);
-
-        ViewGroup.MarginLayoutParams lp = (ViewGroup.MarginLayoutParams)toolbar.getLayoutParams();
-        lp.setMargins(lp.leftMargin, Util.getStatusBarHeight(getActivity()), lp.rightMargin, lp.bottomMargin);
-        toolbar.requestLayout();
     }
 
     @Override

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/player/flat/FlatPlayerFragment.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/player/flat/FlatPlayerFragment.java
@@ -116,6 +116,7 @@ public class FlatPlayerFragment extends AbsPlayerFragment implements PlayerAlbum
         setUpPlayerToolbar();
         setUpStatusBar();
         setUpSubFragments();
+        ViewUtil.setStatusBarHeight(getActivity(), playerStatusBar);
 
         setUpRecyclerView();
 

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/player/flat/FlatPlayerFragment.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/player/flat/FlatPlayerFragment.java
@@ -114,6 +114,7 @@ public class FlatPlayerFragment extends AbsPlayerFragment implements PlayerAlbum
         impl.init();
 
         setUpPlayerToolbar();
+        setUpStatusBar();
         setUpSubFragments();
 
         setUpRecyclerView();
@@ -228,6 +229,12 @@ public class FlatPlayerFragment extends AbsPlayerFragment implements PlayerAlbum
             }
         });
         toolbar.setOnMenuItemClickListener(this);
+    }
+
+    private void setUpStatusBar() {
+        ViewGroup.LayoutParams layoutParams = playerStatusBar.getLayoutParams();
+        layoutParams.height = Util.getStatusBarHeight(getActivity());
+        playerStatusBar.setLayoutParams(layoutParams);
     }
 
     @Override

--- a/app/src/main/java/com/kabouzeid/gramophone/util/Util.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/util/Util.java
@@ -135,4 +135,12 @@ public class Util {
         }
     }
 
+    public static int getStatusBarHeight(final Context context) {
+        int result = 0;
+        int resourceId = context.getResources().getIdentifier("status_bar_height", "dimen", "android");
+        if (resourceId > 0) {
+            result = context.getResources().getDimensionPixelSize(resourceId);
+        }
+        return result;
+    }
 }

--- a/app/src/main/java/com/kabouzeid/gramophone/util/ViewUtil.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/util/ViewUtil.java
@@ -16,6 +16,7 @@ import android.support.annotation.ColorInt;
 import android.support.v4.view.ViewCompat;
 import android.util.DisplayMetrics;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.animation.PathInterpolator;
 import android.widget.TextView;
 
@@ -95,5 +96,11 @@ public class ViewUtil {
     public static float convertPixelsToDp(float px, Resources resources) {
         DisplayMetrics metrics = resources.getDisplayMetrics();
         return px / metrics.density;
+    }
+
+    public static void setStatusBarHeight(final Context context, View statusBar) {
+        ViewGroup.LayoutParams lp = statusBar.getLayoutParams();
+        lp.height = Util.getStatusBarHeight(context);
+        statusBar.requestLayout();
     }
 }

--- a/app/src/main/res/layout/shadow_statusbar_toolbar.xml
+++ b/app/src/main/res/layout/shadow_statusbar_toolbar.xml
@@ -11,6 +11,7 @@
         android:layout_height="wrap_content">
 
         <View
+            android:id="@+id/status_bar"
             android:layout_width="match_parent"
             android:layout_height="@dimen/status_bar_padding" />
 


### PR DESCRIPTION
This fixes issues on devices which have non-standard status bar sizes (i.e. not multiples of 24dp), notably, some Android head units, which have a larger status bar at the top of the screen.

It simply figures out the size of the statusbar at runtime, and resizes the statusbar view in all relevant activities/fragments to ensure the view is not drawing underneath the statusbar.