### PR TITLE
Modified audioFileFilter to recognise .ogg files.

### DIFF
--- a/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/folders/FoldersFragment.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/folders/FoldersFragment.java
@@ -454,7 +454,9 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
     FileFilter audioFileFilter = new FileFilter() {
         @Override
         public boolean accept(File file) {
-            return !file.isHidden() && (file.isDirectory() || FileUtil.fileIsMimeType(file, "audio/*", MimeTypeMap.getSingleton()));
+            return !file.isHidden() && (file.isDirectory() ||
+                FileUtil.fileIsMimeType(file, "audio/*", MimeTypeMap.getSingleton()) ||
+                FileUtil.fileIsMimeType(file, "application/ogg", MimeTypeMap.getSingleton()));
         }
     };
 


### PR DESCRIPTION
Previously any vorbis files (or any other format using the Ogg container) were missing from the folders view.
This is because the Android mime type for .ogg is "application/ogg" rather than "audio/ogg". This pull request simply adds an additional check for this.