### PR TITLE
Put song title text view into a horizontal scrollview so you can see the full song title on songs with longer song titles

### DIFF
--- a/app/src/main/res/layout/item_list.xml
+++ b/app/src/main/res/layout/item_list.xml
@@ -67,13 +67,20 @@
             android:paddingRight="0dp"
             android:paddingStart="16dp">
 
-            <TextView
-                android:id="@+id/title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:fontFamily="sans-serif"
-                android:singleLine="true"
-                android:textAppearance="@style/TextAppearance.AppCompat.Subhead" />
+            <HorizontalScrollView
+                android:layout_width="fill_parent"
+                android:layout_height="fill_parent"
+                android:scrollbars="none">
+
+                <TextView
+                    android:id="@+id/title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="sans-serif"
+                    android:singleLine="true"
+                    android:scrollHorizontally="true"
+                    android:textAppearance="@style/TextAppearance.AppCompat.Subhead" />
+            </HorizontalScrollView>
 
             <TextView
                 android:id="@+id/text"


### PR DESCRIPTION
There's not a lot of room for the song title in the current song view, which means the song title gets cut off most of the time and it's hard to figure out what the full name of the song is without going into the song details dialog. All of this is very annoying. Putting the textview into a horizontal scroll view is an elegant solution because it doesn't compromise any existing functionality, it doesn't change anything and it is very easy for the user to interact with. 