### PR TITLE
Format hours in readable duration string

### DIFF
--- a/app/src/main/java/com/kabouzeid/gramophone/util/MusicUtil.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/util/MusicUtil.java
@@ -100,7 +100,13 @@ public class MusicUtil {
     public static String getReadableDurationString(long songDurationMillis) {
         long minutes = (songDurationMillis / 1000) / 60;
         long seconds = (songDurationMillis / 1000) % 60;
-        return String.format("%01d:%02d", minutes, seconds);
+        if (minutes < 60) {
+            return String.format("%01d:%02d", minutes, seconds);
+        } else {
+            long hours = minutes / 60;
+            minutes = minutes % 60;
+            return String.format("%d:%02d:%02d", hours, minutes, seconds);
+        }
     }
 
     //iTunes uses for example 1002 for track 2 CD1 or 3011 for track 11 CD3.


### PR DESCRIPTION
This is sort of a follow-up to #162.

"Fixes" formatting of readable duration strings so it shows hours separately (e.g. 1:02:31 instead of 62:31).