### PR TITLE
Fix previous/next button order for RTL languages

### DIFF
--- a/app/src/main/res/layout/app_widget_big.xml
+++ b/app/src/main/res/layout/app_widget_big.xml
@@ -20,7 +20,8 @@
         android:layout_alignParentBottom="true"
         android:background="@drawable/shadow_up_strong"
         android:orientation="horizontal"
-        android:padding="16dp">
+        android:padding="16dp"
+        android:layoutDirection="ltr">
 
         <ImageButton
             android:id="@+id/button_prev"

--- a/app/src/main/res/layout/app_widget_classic.xml
+++ b/app/src/main/res/layout/app_widget_classic.xml
@@ -25,7 +25,8 @@
             android:layout_alignParentBottom="true"
             android:layout_gravity="bottom"
             android:orientation="horizontal"
-            android:padding="8dp">
+            android:padding="8dp"
+            android:layoutDirection="ltr">
 
             <ImageButton
                 android:id="@+id/button_prev"

--- a/app/src/main/res/layout/app_widget_small.xml
+++ b/app/src/main/res/layout/app_widget_small.xml
@@ -20,7 +20,8 @@
         android:layout_gravity="fill_horizontal"
         android:focusable="true"
         android:gravity="center_horizontal"
-        android:orientation="horizontal">
+        android:orientation="horizontal"
+        android:layoutDirection="ltr">
 
         <ImageButton
             android:id="@+id/button_prev"

--- a/app/src/main/res/layout/fragment_card_player_playback_controls.xml
+++ b/app/src/main/res/layout/fragment_card_player_playback_controls.xml
@@ -54,6 +54,7 @@
         android:id="@+id/player_media_controller_container"
         android:layout_width="match_parent"
         android:layout_height="@dimen/fab_media_controller_container_height"
+        android:layoutDirection="ltr"
         tools:ignore="ContentDescription,UnusedAttribute">
 
         <ImageButton

--- a/app/src/main/res/layout/fragment_flat_player_playback_controls.xml
+++ b/app/src/main/res/layout/fragment_flat_player_playback_controls.xml
@@ -56,6 +56,7 @@
         android:id="@+id/player_media_controller_container"
         android:layout_width="match_parent"
         android:layout_height="@dimen/media_controller_container_height"
+        android:layoutDirection="ltr"
         tools:ignore="ContentDescription,UnusedAttribute">
 
         <ImageButton


### PR DESCRIPTION
Closes https://github.com/kabouzeid/phonograph-issue-tracker/issues/34.

Tested with Arabic. This is a fix for both now playing screen layouts and the 3 widgets. Note that this likely doesn't work in Android 4.1 since `android:layoutDirection` is API 17+.