### PR TITLE
Prevent flat controls from animating on every show

### DIFF
--- a/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/player/flat/FlatPlayerPlaybackControlsFragment.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/player/flat/FlatPlayerPlaybackControlsFragment.java
@@ -67,6 +67,8 @@ public class FlatPlayerPlaybackControlsFragment extends AbsMusicServiceFragment 
 
     private AnimatorSet musicControllerAnimationSet;
 
+    private boolean hidden = false;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -253,25 +255,28 @@ public class FlatPlayerPlaybackControlsFragment extends AbsMusicServiceFragment 
     }
 
     public void show() {
-        if (musicControllerAnimationSet == null) {
-            TimeInterpolator interpolator = new FastOutSlowInInterpolator();
-            final int duration = 300;
+        if (hidden) {
+            if (musicControllerAnimationSet == null) {
+                TimeInterpolator interpolator = new FastOutSlowInInterpolator();
+                final int duration = 300;
 
-            LinkedList<Animator> animators = new LinkedList<>();
+                LinkedList<Animator> animators = new LinkedList<>();
 
-            addAnimation(animators, playPauseButton, interpolator, duration, 0);
-            addAnimation(animators, nextButton, interpolator, duration, 100);
-            addAnimation(animators, prevButton, interpolator, duration, 100);
-            addAnimation(animators, shuffleButton, interpolator, duration, 200);
-            addAnimation(animators, repeatButton, interpolator, duration, 200);
+                addAnimation(animators, playPauseButton, interpolator, duration, 0);
+                addAnimation(animators, nextButton, interpolator, duration, 100);
+                addAnimation(animators, prevButton, interpolator, duration, 100);
+                addAnimation(animators, shuffleButton, interpolator, duration, 200);
+                addAnimation(animators, repeatButton, interpolator, duration, 200);
 
-
-            musicControllerAnimationSet = new AnimatorSet();
-            musicControllerAnimationSet.playTogether(animators);
-        } else {
-            musicControllerAnimationSet.cancel();
+                musicControllerAnimationSet = new AnimatorSet();
+                musicControllerAnimationSet.playTogether(animators);
+            } else {
+                musicControllerAnimationSet.cancel();
+            }
+            musicControllerAnimationSet.start();
         }
-        musicControllerAnimationSet.start();
+
+        hidden = false;
     }
 
     public void hide() {
@@ -283,6 +288,8 @@ public class FlatPlayerPlaybackControlsFragment extends AbsMusicServiceFragment 
         prepareForAnimation(prevButton);
         prepareForAnimation(shuffleButton);
         prepareForAnimation(repeatButton);
+
+        hidden = true;
     }
 
     private static void addAnimation(Collection<Animator> animators, View view, TimeInterpolator interpolator, int duration, int delay) {


### PR DESCRIPTION
Closes #101.

I originally wanted to modify `addAnimation` so it would go from `view.getScaleX()`/`view.getScaleY()` to `1f`, but it seems the end value is set as `0f` despite it animating to `1f`. On a similar note, `prepareForAnimation` doesn't actually seem necessary, as the views' scales implicitly get set to `0f` when the `Animator`s are set anyway. I wasn't sure if it was required for some reason though.