### PR TITLE
Add git branch name to debug app's version name

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,6 +19,15 @@ repositories {
     maven { url 'https://maven.fabric.io/public' }
 }
 
+def gitBranch() {
+    def branch = ''
+    def proc = 'git rev-parse --abbrev-ref HEAD'.execute()
+    proc.in.eachLine { line -> branch = line }
+    proc.err.eachLine { line -> println line }
+    proc.waitFor()
+    branch
+}
+
 android {
     compileSdkVersion 25
     buildToolsVersion '25.0.3'
@@ -44,7 +53,7 @@ android {
         }
         debug {
             applicationIdSuffix '.debug'
-            versionNameSuffix ' DEBUG'
+            versionNameSuffix ' DEBUG (' + gitBranch() + ')'
 
             ext.enableCrashlytics = false // Disable fabric build ID generation for debug builds
         }


### PR DESCRIPTION
For example, it'll say "0.15.0 DEBUG (version-name-branch)". I just wanted to add this since I often forget which branch's build I have on my device.