### PR TITLE
[WIP] Update support libs and build tools to v26

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,16 +29,16 @@ def gitBranch() {
 }
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    compileSdkVersion 26
+    buildToolsVersion '26.0.1'
     dataBinding {
         enabled = true
     }
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 26
 
-        renderscriptTargetApi 25
+        renderscriptTargetApi 26
         vectorDrawables.useSupportLibrary = true
 
         applicationId 'com.kabouzeid.gramophone'
@@ -70,7 +70,7 @@ android {
 }
 
 ext {
-    supportLibVersion = '25.4.0'
+    supportLibVersion = '26.0.1'
 }
 
 dependencies {

--- a/app/src/main/java/com/kabouzeid/gramophone/service/notification/PlayingNotification.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/service/notification/PlayingNotification.java
@@ -10,6 +10,8 @@ import static android.content.Context.NOTIFICATION_SERVICE;
 public abstract class PlayingNotification {
 
     private static final int NOTIFICATION_ID = 1;
+    protected static final String NOTIFICATION_CHANNEL = "notif_channel";
+
     private static final int NOTIFY_MODE_FOREGROUND = 1;
     private static final int NOTIFY_MODE_BACKGROUND = 0;
 

--- a/app/src/main/java/com/kabouzeid/gramophone/service/notification/PlayingNotificationImpl.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/service/notification/PlayingNotificationImpl.java
@@ -71,7 +71,7 @@ public class PlayingNotificationImpl extends PlayingNotification {
         final PendingIntent clickIntent = PendingIntent.getActivity(service, 0, action, 0);
         final PendingIntent deleteIntent = buildPendingIntent(service, MusicService.ACTION_QUIT, null);
 
-        final Notification notification = new NotificationCompat.Builder(service)
+        final Notification notification = new NotificationCompat.Builder(service, NOTIFICATION_CHANNEL)
                 .setSmallIcon(R.drawable.ic_notification)
                 .setContentIntent(clickIntent)
                 .setDeleteIntent(deleteIntent)

--- a/app/src/main/java/com/kabouzeid/gramophone/service/notification/PlayingNotificationImpl24.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/service/notification/PlayingNotificationImpl24.java
@@ -8,7 +8,8 @@ import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
-import android.support.v7.app.NotificationCompat;
+import android.support.v4.app.NotificationCompat;
+import android.support.v4.media.app.NotificationCompat.MediaStyle;
 import android.support.v7.graphics.Palette;
 import android.text.TextUtils;
 
@@ -84,7 +85,7 @@ public class PlayingNotificationImpl24 extends PlayingNotification {
                                 NotificationCompat.Action nextAction = new NotificationCompat.Action(R.drawable.ic_skip_next_white_24dp,
                                         service.getString(R.string.action_next),
                                         retrievePlaybackAction(ACTION_SKIP));
-                                NotificationCompat.Builder builder = (NotificationCompat.Builder) new NotificationCompat.Builder(service)
+                                NotificationCompat.Builder builder = new NotificationCompat.Builder(service, NOTIFICATION_CHANNEL)
                                         .setSmallIcon(R.drawable.ic_notification)
                                         .setLargeIcon(bitmap)
                                         .setContentIntent(clickIntent)
@@ -98,7 +99,7 @@ public class PlayingNotificationImpl24 extends PlayingNotification {
                                         .addAction(nextAction);
 
                                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                                    builder.setStyle(new NotificationCompat.MediaStyle().setMediaSession(service.getMediaSession().getSessionToken()).setShowActionsInCompactView(0, 1, 2))
+                                    builder.setStyle(new MediaStyle().setMediaSession(service.getMediaSession().getSessionToken()).setShowActionsInCompactView(0, 1, 2))
                                             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC);
                                     if (PreferenceUtil.getInstance(service).coloredNotification())
                                         builder.setColor(color);


### PR DESCRIPTION
This is currently blocked by https://github.com/h6ah4i/android-advancedrecyclerview/issues/396.

We should also consider using the native `fastScrollEnabled` flag for `RecyclerView`s ([see changelog](https://developer.android.com/topic/libraries/support-library/revisions.html#26-0-0) for more info).