### PR TITLE
Save current playing queue as playlist

### DIFF
--- a/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/player/AbsPlayerFragment.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/player/AbsPlayerFragment.java
@@ -7,6 +7,7 @@ import android.view.MenuItem;
 
 import com.kabouzeid.gramophone.R;
 import com.kabouzeid.gramophone.dialogs.AddToPlaylistDialog;
+import com.kabouzeid.gramophone.dialogs.CreatePlaylistDialog;
 import com.kabouzeid.gramophone.dialogs.SleepTimerDialog;
 import com.kabouzeid.gramophone.dialogs.SongDetailDialog;
 import com.kabouzeid.gramophone.dialogs.SongShareDialog;
@@ -61,6 +62,9 @@ public abstract class AbsPlayerFragment extends AbsMusicServiceFragment implemen
                 return true;
             case R.id.action_clear_playing_queue:
                 MusicPlayerRemote.clearQueue();
+                return true;
+            case R.id.action_save_playing_queue:
+                CreatePlaylistDialog.create(MusicPlayerRemote.getPlayingQueue()).show(getActivity().getSupportFragmentManager(), "ADD_TO_PLAYLIST");
                 return true;
             case R.id.action_tag_editor:
                 Intent intent = new Intent(getActivity(), SongTagEditorActivity.class);

--- a/app/src/main/res/menu/menu_player.xml
+++ b/app/src/main/res/menu/menu_player.xml
@@ -15,6 +15,12 @@
         app:showAsAction="never" />
 
     <item
+        android:id="@+id/action_save_playing_queue"
+        android:orderInCategory="1"
+        android:title="@string/action_save_playing_queue"
+        app:showAsAction="never" />
+
+    <item
         android:id="@+id/action_sleep_timer"
         android:orderInCategory="1"
         android:title="@string/action_sleep_timer"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -103,6 +103,7 @@
     <string name="action_shuffle_artist">Shuffle artist</string>
     <string name="action_shuffle_playlist">Shuffle playlist</string>
     <string name="action_clear_playing_queue">Clear playing queue</string>
+    <string name="action_save_playing_queue">Save playing queue</string>
     <string name="action_go_to_start_directory">Go to start directory</string>
     <string name="action_show_lyrics">Show lyrics</string>
     <string name="last_opened">Last opened</string>


### PR DESCRIPTION
Adds a menu item to the now playing screen to save the current queue as a new playlist.

Closes https://github.com/kabouzeid/phonograph-issue-tracker/issues/6