### PR TITLE
Add menu actions to playlist detail activity

### DIFF
--- a/app/src/main/res/menu/menu_playlist_detail.xml
+++ b/app/src/main/res/menu/menu_playlist_detail.xml
@@ -10,14 +10,24 @@
         app:showAsAction="ifRoom" />
 
     <item
-        android:id="@+id/action_sleep_timer"
-        android:title="@string/action_sleep_timer"
+        android:id="@+id/action_play"
+        android:title="@string/action_play"
         app:showAsAction="never" />
-
     <item
-        android:id="@+id/action_equalizer"
-        android:orderInCategory="99"
-        android:title="@string/equalizer"
+        android:id="@+id/action_add_to_current_playing"
+        android:title="@string/action_add_to_playing_queue"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/action_rename_playlist"
+        android:title="@string/action_rename"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/action_delete_playlist"
+        android:title="@string/action_delete"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/action_save_playlist"
+        android:title="@string/save_playlist_title"
         app:showAsAction="never" />
 
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,6 +71,7 @@
     <string name="inserted_x_songs_into_playlist_x">Inserted %1$d songs into the playlist %2$s.</string>
     <string name="created_playlist_x">Created playlist %1$s.</string>
     <string name="deleted_x_songs">Deleted %1$d songs.</string>
+    <string name="playlist_exists">Playlist %1$s already exists.</string>
     <string name="could_not_create_playlist">Couldn\u2019t create playlist.</string>
     <string name="delete_playlist_x"><![CDATA[Delete the playlist <b>%1$s</b>?]]></string>
     <string name="clear_playlist_x"><![CDATA[Clear the playlist <b>%1$s</b>? This can\u2019t be undone!]]></string>


### PR DESCRIPTION
Closes #232.

- Adds "Play", "Add to playing queue", "Rename", "Delete", and "Save as file" to the playlist detail activity view
- Renaming the playlist updates the name in the activity
- Deleting the playlist exits out of it

There's no logic to deal with Favorites though. I think Favorites should be converted into a special playlist that appears at the top of the list (with Last added, History, and My top tracks), but can't be renamed/deleted.
