### PR TITLE
Shuffle all row in songs grid

### DIFF
--- a/app/src/main/java/com/kabouzeid/gramophone/adapter/song/AbsOffsetSongAdapter.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/adapter/song/AbsOffsetSongAdapter.java
@@ -20,8 +20,8 @@ import java.util.ArrayList;
  */
 public abstract class AbsOffsetSongAdapter extends SongAdapter {
 
-    protected static final int OFFSET_ITEM = 0;
-    protected static final int SONG = 1;
+    public static final int OFFSET_ITEM = 0;
+    public static final int SONG_ITEM = 1;
 
     public AbsOffsetSongAdapter(AppCompatActivity activity, ArrayList<Song> dataSet, @LayoutRes int itemLayoutRes, boolean usePalette, @Nullable CabHolder cabHolder) {
         super(activity, dataSet, itemLayoutRes, usePalette, cabHolder);
@@ -68,7 +68,7 @@ public abstract class AbsOffsetSongAdapter extends SongAdapter {
 
     @Override
     public int getItemViewType(int position) {
-        return position == 0 ? OFFSET_ITEM : SONG;
+        return position == 0 ? OFFSET_ITEM : SONG_ITEM;
     }
 
     @NonNull

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/pager/SongsFragment.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/pager/SongsFragment.java
@@ -8,6 +8,7 @@ import android.support.v4.content.Loader;
 import android.support.v7.widget.GridLayoutManager;
 
 import com.kabouzeid.gramophone.R;
+import com.kabouzeid.gramophone.adapter.song.AbsOffsetSongAdapter;
 import com.kabouzeid.gramophone.adapter.song.ShuffleButtonSongAdapter;
 import com.kabouzeid.gramophone.adapter.song.SongAdapter;
 import com.kabouzeid.gramophone.interfaces.LoaderIds;
@@ -36,7 +37,19 @@ public class SongsFragment extends AbsLibraryPagerRecyclerViewCustomGridSizeFrag
     @NonNull
     @Override
     protected GridLayoutManager createLayoutManager() {
-        return new GridLayoutManager(getActivity(), getGridSize());
+        final GridLayoutManager layoutManager = new GridLayoutManager(getActivity(), getGridSize());
+        layoutManager.setSpanSizeLookup(new GridLayoutManager.SpanSizeLookup() {
+            @Override
+            public int getSpanSize(int position) {
+                switch (getAdapter().getItemViewType(position)) {
+                    case AbsOffsetSongAdapter.OFFSET_ITEM:
+                        return layoutManager.getSpanCount();
+                    default:
+                        return 1;
+                }
+            }
+        });
+        return layoutManager;
     }
 
     @NonNull
@@ -47,15 +60,7 @@ public class SongsFragment extends AbsLibraryPagerRecyclerViewCustomGridSizeFrag
         boolean usePalette = loadUsePalette();
         ArrayList<Song> dataSet = getAdapter() == null ? new ArrayList<Song>() : getAdapter().getDataSet();
 
-        if (getGridSize() <= getMaxGridSizeForList()) {
-            return new ShuffleButtonSongAdapter(
-                    getLibraryFragment().getMainActivity(),
-                    dataSet,
-                    itemLayoutRes,
-                    usePalette,
-                    getLibraryFragment());
-        }
-        return new SongAdapter(
+        return new ShuffleButtonSongAdapter(
                 getLibraryFragment().getMainActivity(),
                 dataSet,
                 itemLayoutRes,


### PR DESCRIPTION
Fixes #270. Looks a bit weird though, might be better just to add it back to the overflow menu.

![screenshot_20170908-232408](https://user-images.githubusercontent.com/4098258/30236698-3a83d164-94ed-11e7-913c-1ac58ff982c0.png)
