### PR TITLE
Improve toolbar scrim

### DIFF
--- a/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/player/AbsPlayerFragment.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/player/AbsPlayerFragment.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.support.v7.widget.Toolbar;
 import android.view.MenuItem;
+import android.view.View;
 
 import com.kabouzeid.gramophone.R;
 import com.kabouzeid.gramophone.dialogs.AddToPlaylistDialog;
@@ -24,10 +25,12 @@ public abstract class AbsPlayerFragment extends AbsMusicServiceFragment implemen
     public static final String TAG = AbsPlayerFragment.class.getSimpleName();
 
     private Callbacks callbacks;
+    private boolean isToolbarVisible;
 
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);
+        isToolbarVisible = true;
         try {
             callbacks = (Callbacks) context;
         } catch (ClassCastException e) {
@@ -86,6 +89,23 @@ public abstract class AbsPlayerFragment extends AbsMusicServiceFragment implemen
 
     protected void toggleFavorite(Song song) {
         MusicUtil.toggleFavorite(getActivity(), song);
+    }
+
+    protected void toggleToolbar(final View toolbar) {
+        if (toolbar == null) return;
+
+        isToolbarVisible = !isToolbarVisible;
+        if (isToolbarVisible) {
+            toolbar.setVisibility(View.VISIBLE);
+            toolbar.animate().alpha(1f).setDuration(PlayerAlbumCoverFragment.VISIBILITY_ANIM_DURATION);
+        } else {
+            toolbar.animate().alpha(0f).setDuration(PlayerAlbumCoverFragment.VISIBILITY_ANIM_DURATION).withEndAction(new Runnable() {
+                @Override
+                public void run() {
+                    toolbar.setVisibility(View.GONE);
+                }
+            });
+        }
     }
 
     protected String getUpNextAndQueueTime() {

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/player/PlayerAlbumCoverFragment.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/player/PlayerAlbumCoverFragment.java
@@ -35,7 +35,7 @@ import butterknife.Unbinder;
 public class PlayerAlbumCoverFragment extends AbsMusicServiceFragment implements ViewPager.OnPageChangeListener, MusicProgressViewUpdateHelper.Callback {
     public static final String TAG = PlayerAlbumCoverFragment.class.getSimpleName();
 
-    public static final int LYRICS_ANIM_DURATION = 300;
+    public static final int VISIBILITY_ANIM_DURATION = 300;
 
     private Unbinder unbinder;
 
@@ -71,6 +71,15 @@ public class PlayerAlbumCoverFragment extends AbsMusicServiceFragment implements
         viewPager.addOnPageChangeListener(this);
         viewPager.setOnTouchListener(new View.OnTouchListener() {
             GestureDetector gestureDetector = new GestureDetector(getActivity(), new GestureDetector.SimpleOnGestureListener() {
+                @Override
+                public boolean onSingleTapConfirmed(MotionEvent e) {
+                    if (callbacks != null) {
+                        callbacks.onToolbarToggled();
+                        return true;
+                    }
+                    return super.onSingleTapConfirmed(e);
+                }
+
                 @Override
                 public boolean onDoubleTap(MotionEvent e) {
                     if (callbacks != null) {
@@ -121,7 +130,6 @@ public class PlayerAlbumCoverFragment extends AbsMusicServiceFragment implements
 
     @Override
     public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
-
     }
 
     @Override
@@ -144,7 +152,6 @@ public class PlayerAlbumCoverFragment extends AbsMusicServiceFragment implements
 
     @Override
     public void onPageScrollStateChanged(int state) {
-
     }
 
     public void showHeartAnimation() {
@@ -193,7 +200,7 @@ public class PlayerAlbumCoverFragment extends AbsMusicServiceFragment implements
     }
 
     private void hideLyricsLayout() {
-        lyricsLayout.animate().alpha(0f).setDuration(PlayerAlbumCoverFragment.LYRICS_ANIM_DURATION).withEndAction(new Runnable() {
+        lyricsLayout.animate().alpha(0f).setDuration(PlayerAlbumCoverFragment.VISIBILITY_ANIM_DURATION).withEndAction(new Runnable() {
             @Override
             public void run() {
                 if (!isLyricsLayoutBound()) return;
@@ -218,7 +225,7 @@ public class PlayerAlbumCoverFragment extends AbsMusicServiceFragment implements
         lyricsLine2.setText(null);
 
         lyricsLayout.setVisibility(View.VISIBLE);
-        lyricsLayout.animate().alpha(1f).setDuration(PlayerAlbumCoverFragment.LYRICS_ANIM_DURATION);
+        lyricsLayout.animate().alpha(1f).setDuration(PlayerAlbumCoverFragment.VISIBILITY_ANIM_DURATION);
     }
 
     private void notifyColorChange(int color) {
@@ -259,11 +266,11 @@ public class PlayerAlbumCoverFragment extends AbsMusicServiceFragment implements
 
             lyricsLine1.setAlpha(1f);
             lyricsLine1.setTranslationY(0f);
-            lyricsLine1.animate().alpha(0f).translationY(-h).setDuration(PlayerAlbumCoverFragment.LYRICS_ANIM_DURATION);
+            lyricsLine1.animate().alpha(0f).translationY(-h).setDuration(PlayerAlbumCoverFragment.VISIBILITY_ANIM_DURATION);
 
             lyricsLine2.setAlpha(0f);
             lyricsLine2.setTranslationY(h);
-            lyricsLine2.animate().alpha(1f).translationY(0f).setDuration(PlayerAlbumCoverFragment.LYRICS_ANIM_DURATION);
+            lyricsLine2.animate().alpha(1f).translationY(0f).setDuration(PlayerAlbumCoverFragment.VISIBILITY_ANIM_DURATION);
         }
     }
 
@@ -271,5 +278,7 @@ public class PlayerAlbumCoverFragment extends AbsMusicServiceFragment implements
         void onColorChanged(int color);
 
         void onFavoriteToggled();
+
+        void onToolbarToggled();
     }
 }

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/player/card/CardPlayerFragment.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/player/card/CardPlayerFragment.java
@@ -10,6 +10,7 @@ import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.ColorInt;
+import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.CardView;
 import android.support.v7.widget.LinearLayoutManager;
@@ -23,6 +24,7 @@ import android.view.View;
 import android.view.ViewAnimationUtils;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
+import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.TextView;
 
@@ -61,6 +63,9 @@ public class CardPlayerFragment extends AbsPlayerFragment implements PlayerAlbum
 
     private Unbinder unbinder;
 
+    @Nullable
+    @BindView(R.id.toolbar_container)
+    FrameLayout toolbarContainer;
     @BindView(R.id.player_toolbar)
     Toolbar toolbar;
     @BindView(R.id.player_sliding_layout)
@@ -267,7 +272,6 @@ public class CardPlayerFragment extends AbsPlayerFragment implements PlayerAlbum
         layoutManager.scrollToPositionWithOffset(MusicPlayerRemote.getPosition() + 1, 0);
     }
 
-
     private void updateIsFavorite() {
         if (updateIsFavoriteTask != null) updateIsFavoriteTask.cancel(false);
         updateIsFavoriteTask = new AsyncTask<Song, Void, Boolean>() {
@@ -401,6 +405,11 @@ public class CardPlayerFragment extends AbsPlayerFragment implements PlayerAlbum
     @Override
     public void onFavoriteToggled() {
         toggleFavorite(MusicPlayerRemote.getCurrentSong());
+    }
+
+    @Override
+    public void onToolbarToggled() {
+        toggleToolbar(toolbarContainer);
     }
 
     @Override

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/player/flat/FlatPlayerFragment.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/player/flat/FlatPlayerFragment.java
@@ -21,6 +21,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
+import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.TextView;
 
@@ -61,6 +62,9 @@ public class FlatPlayerFragment extends AbsPlayerFragment implements PlayerAlbum
 
     @BindView(R.id.player_status_bar)
     View playerStatusBar;
+    @Nullable
+    @BindView(R.id.toolbar_container)
+    FrameLayout toolbarContainer;
     @BindView(R.id.player_toolbar)
     Toolbar toolbar;
     @Nullable
@@ -263,7 +267,6 @@ public class FlatPlayerFragment extends AbsPlayerFragment implements PlayerAlbum
         layoutManager.scrollToPositionWithOffset(MusicPlayerRemote.getPosition() + 1, 0);
     }
 
-
     private void updateIsFavorite() {
         if (updateIsFavoriteTask != null) updateIsFavoriteTask.cancel(false);
         updateIsFavoriteTask = new AsyncTask<Song, Void, Boolean>() {
@@ -397,6 +400,11 @@ public class FlatPlayerFragment extends AbsPlayerFragment implements PlayerAlbum
     @Override
     public void onFavoriteToggled() {
         toggleFavorite(MusicPlayerRemote.getCurrentSong());
+    }
+
+    @Override
+    public void onToolbarToggled() {
+        toggleToolbar(toolbarContainer);
     }
 
     @Override

--- a/app/src/main/res/drawable/toolbar_gradient.xml
+++ b/app/src/main/res/drawable/toolbar_gradient.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <gradient
+        android:angle="90"
+        android:centerY="0.33"
+        android:endColor="@color/thirty_three_percent_black_overlay"
+        android:startColor="#00000000" />
+</shape>

--- a/app/src/main/res/layout/fragment_card_player.xml
+++ b/app/src/main/res/layout/fragment_card_player.xml
@@ -58,13 +58,21 @@
 
             </RelativeLayout>
 
-            <include layout="@layout/shadow_statusbar_toolbar" />
+            <FrameLayout
+                android:id="@+id/toolbar_container"
+                android:layout_width="wrap_content"
+                android:layout_height="@dimen/toolbar_scrim_height"
+                android:background="@drawable/toolbar_gradient">
 
-            <android.support.v7.widget.Toolbar
-                android:id="@+id/player_toolbar"
-                style="@style/Toolbar"
-                android:layout_marginTop="@dimen/status_bar_padding"
-                android:background="@android:color/transparent" />
+                <include layout="@layout/shadow_statusbar_toolbar" />
+
+                <android.support.v7.widget.Toolbar
+                    android:id="@+id/player_toolbar"
+                    style="@style/Toolbar"
+                    android:layout_marginTop="@dimen/status_bar_padding"
+                    android:background="@android:color/transparent" />
+
+            </FrameLayout>
 
         </FrameLayout>
 

--- a/app/src/main/res/layout/fragment_flat_player.xml
+++ b/app/src/main/res/layout/fragment_flat_player.xml
@@ -56,12 +56,18 @@
 
             </FrameLayout>
 
-            <include layout="@layout/shadow_toolbar" />
+            <FrameLayout
+                android:id="@+id/toolbar_container"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/toolbar_scrim_height"
+                android:background="@drawable/toolbar_gradient">
 
-            <android.support.v7.widget.Toolbar
-                android:id="@+id/player_toolbar"
-                style="@style/Toolbar"
-                android:background="@android:color/transparent" />
+                <android.support.v7.widget.Toolbar
+                    android:id="@+id/player_toolbar"
+                    style="@style/Toolbar"
+                    android:background="@android:color/transparent" />
+
+            </FrameLayout>
 
         </FrameLayout>
 

--- a/app/src/main/res/layout/navigation_drawer_header.xml
+++ b/app/src/main/res/layout/navigation_drawer_header.xml
@@ -19,7 +19,7 @@
 
     <View
         android:layout_width="match_parent"
-        android:layout_height="56dp"
+        android:layout_height="112dp"
         android:layout_gravity="bottom"
         android:background="@drawable/shadow_up" />
 

--- a/app/src/main/res/layout/shadow_statusbar_toolbar.xml
+++ b/app/src/main/res/layout/shadow_statusbar_toolbar.xml
@@ -22,9 +22,9 @@
 
     <View
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="@dimen/toolbar_scrim_height"
         android:layout_alignBottom="@id/dummy_statusbar_actionbar"
         android:layout_alignTop="@id/dummy_statusbar_actionbar"
-        android:background="@drawable/shadow_down" />
+        android:background="@drawable/toolbar_gradient" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/shadow_toolbar.xml
+++ b/app/src/main/res/layout/shadow_toolbar.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<View xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="?actionBarSize"
-    android:background="@drawable/shadow_down" />

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="twenty_percent_black_overlay">#34000000</color>
+    <color name="thirty_three_percent_black_overlay">#54000000</color>
 
     <color name="app_shortcut_default_foreground">#607d8b</color>
     <color name="app_shortcut_default_background">#f5f5f5</color>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -6,6 +6,9 @@
     <dimen name="toolbar_elevation">4dp</dimen>
     <dimen name="card_elevation">2dp</dimen>
 
+    <!-- 3x standard action bar height (56dp) -->
+    <dimen name="toolbar_scrim_height">168dp</dimen>
+
     <dimen name="header_image_height">360dp</dimen>
     <dimen name="progress_container_height">20dp</dimen>
     <dimen name="fab_media_controller_container_height">120dp</dimen>


### PR DESCRIPTION
Fixes #69.

Improved protection shadow for the status/toolbar in portrait player layouts, and also increased the height of the scrim for the navigation menu's album art text so it works better.

Also added the ability to single-tap the album art in the player to toggle the visibility of the toolbar (and its scrim).