### PR TITLE
Try to get file path from DATA column of Uri

### DIFF
--- a/app/src/main/java/com/kabouzeid/gramophone/helper/MusicPlayerRemote.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/helper/MusicPlayerRemote.java
@@ -8,6 +8,7 @@ import android.content.Context;
 import android.content.ContextWrapper;
 import android.content.Intent;
 import android.content.ServiceConnection;
+import android.database.Cursor;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Environment;
@@ -16,6 +17,7 @@ import android.provider.DocumentsContract;
 import android.provider.MediaStore;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.util.Log;
 import android.widget.Toast;
 
 import com.kabouzeid.gramophone.R;
@@ -413,6 +415,11 @@ public class MusicPlayerRemote {
                 if (uri.getAuthority() != null && uri.getAuthority().equals("com.android.externalstorage.documents")) {
                     songFile = new File(Environment.getExternalStorageDirectory(), uri.getPath().split(":", 2)[1]);
                 }
+                if (songFile == null) {
+                    String path = getFilePathFromUri(musicService, uri);
+                    if (path != null)
+                        songFile = new File(path);
+                }
                 if (songFile == null && uri.getPath() != null) {
                     songFile = new File(uri.getPath());
                 }
@@ -430,6 +437,30 @@ public class MusicPlayerRemote {
                 //TODO the file is not listed in the media store
             }
         }
+    }
+    @Nullable
+    private static String getFilePathFromUri(Context context, Uri uri)
+    {
+        Cursor cursor = null;
+        final String column = "_data";
+        final String[] projection = {
+                column
+        };
+
+        try {
+            cursor = context.getContentResolver().query(uri, projection, null, null,
+                    null);
+            if (cursor != null && cursor.moveToFirst()) {
+                final int column_index = cursor.getColumnIndexOrThrow(column);
+                return cursor.getString(column_index);
+            }
+        } catch (Exception e) {
+            Log.e(TAG, e.getMessage());
+        } finally {
+            if (cursor != null)
+                cursor.close();
+        }
+        return null;
     }
 
     @TargetApi(Build.VERSION_CODES.KITKAT)


### PR DESCRIPTION
When clicking on music files in some file exploring apps, Phonograph opens but does nothing, because there is `Uri.getPath()` does not return a real file path. This change allows Phonograph to open and play for some file explorers that it couldn't previously (Samsung's "My Files" being a big one). 

It still doesn't work for some Uri's, like ones from Astro Explorer. Ideally it'd use `ContentResolver` to get a `FileDescriptor` for these Uri's and open that in the `MediaPlayer`, but that looks like a major change.