### PR TITLE
Fix album with year "0" - Issues #121 and #355

### DIFF
--- a/app/src/main/java/com/kabouzeid/gramophone/adapter/album/HorizontalAlbumAdapter.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/adapter/album/HorizontalAlbumAdapter.java
@@ -76,7 +76,11 @@ public class HorizontalAlbumAdapter extends AlbumAdapter {
 
     @Override
     protected String getAlbumText(Album album) {
-        return String.valueOf(album.getYear());
+		int year = album.getYear();
+		if(year > 0) {
+			return String.valueOf(year);
+		}
+		return "";
     }
 
     @Override

--- a/app/src/main/java/com/kabouzeid/gramophone/adapter/album/HorizontalAlbumAdapter.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/adapter/album/HorizontalAlbumAdapter.java
@@ -80,7 +80,7 @@ public class HorizontalAlbumAdapter extends AlbumAdapter {
 		if(year > 0) {
 			return String.valueOf(year);
 		}
-		return "";
+		return "-";
     }
 
     @Override


### PR DESCRIPTION
If the year of the Album has not a valid value (i.e. year <= 0), do not use it in the Album text.
This fixes issues #121 and #355