### PR TITLE
Let it snow! - Added snowflakes option

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,7 +30,7 @@ static def gitBranch() {
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.0'
+    buildToolsVersion '27.0.2'
     dataBinding {
         enabled = true
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -97,7 +97,7 @@ dependencies {
     implementation 'com.github.kabouzeid:RecyclerView-FastScroll:1.0.16-kmod'
     implementation 'com.github.kabouzeid:SeekArc:1.2-kmod'
     implementation 'com.github.kabouzeid:AndroidSlidingUpPanel:3.3.0-kmod3'
-    implementation 'com.afollestad.material-dialogs:core:0.9.4.5'
+    implementation 'com.afollestad.material-dialogs:core:0.9.5.0'
     implementation 'com.afollestad.material-dialogs:commons:0.9.4.5'
     implementation 'com.afollestad:material-cab:0.1.12'
     implementation 'com.github.ksoichiro:android-observablescrollview:1.6.0'
@@ -108,7 +108,7 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:3.8.0'
     implementation 'com.github.bumptech.glide:okhttp3-integration:1.5.0'
     implementation 'com.heinrichreimersoftware:material-intro:1.6.2'
-    implementation 'me.zhanghai.android.materialprogressbar:library:1.4.1'
+    implementation 'me.zhanghai.android.materialprogressbar:library:1.4.2'
     implementation 'org.eclipse.mylyn.github:org.eclipse.egit.github.core:2.1.5'
     implementation 'com.jakewharton:butterknife:8.6.0'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -110,6 +110,7 @@ dependencies {
     implementation 'com.heinrichreimersoftware:material-intro:1.6.2'
     implementation 'me.zhanghai.android.materialprogressbar:library:1.4.2'
     implementation 'org.eclipse.mylyn.github:org.eclipse.egit.github.core:2.1.5'
+    implementation 'com.github.jetradarmobile:android-snowfall:1.1.6'
     implementation 'com.jakewharton:butterknife:8.6.0'
 
     implementation('com.h6ah4i.android.widget.advrecyclerview:advrecyclerview:0.11.0@aar') {

--- a/app/src/main/java/com/kabouzeid/gramophone/App.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/App.java
@@ -67,7 +67,7 @@ public class App extends Application {
     }
 
     public static boolean isProVersion() {
-        return true;
+        return BuildConfig.DEBUG || app.billingProcessor.isPurchased(PRO_VERSION_PRODUCT_ID);
     }
 
     public static App getInstance() {

--- a/app/src/main/java/com/kabouzeid/gramophone/App.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/App.java
@@ -67,7 +67,7 @@ public class App extends Application {
     }
 
     public static boolean isProVersion() {
-        return BuildConfig.DEBUG || app.billingProcessor.isPurchased(PRO_VERSION_PRODUCT_ID);
+        return true;
     }
 
     public static App getInstance() {

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/activities/AlbumDetailActivity.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/activities/AlbumDetailActivity.java
@@ -27,6 +27,7 @@ import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.RequestListener;
 import com.bumptech.glide.request.target.Target;
 import com.github.ksoichiro.android.observablescrollview.ObservableRecyclerView;
+import com.jetradarmobile.snowfall.SnowfallView;
 import com.kabouzeid.appthemehelper.util.ColorUtil;
 import com.kabouzeid.appthemehelper.util.MaterialValueHelper;
 import com.kabouzeid.gramophone.R;
@@ -53,6 +54,7 @@ import com.kabouzeid.gramophone.ui.activities.tageditor.AbsTagEditorActivity;
 import com.kabouzeid.gramophone.ui.activities.tageditor.AlbumTagEditorActivity;
 import com.kabouzeid.gramophone.util.NavigationUtil;
 import com.kabouzeid.gramophone.util.PhonographColorUtil;
+import com.kabouzeid.gramophone.util.PreferenceUtil;
 import com.kabouzeid.gramophone.util.Util;
 
 import java.util.Locale;
@@ -118,6 +120,14 @@ public class AlbumDetailActivity extends AbsSlidingMusicPanelActivity implements
         setUpViews();
 
         getSupportLoaderManager().initLoader(LOADER_ID, getIntent().getExtras(), this);
+
+        checkEnableSnowfall();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        checkEnableSnowfall();
     }
 
     @Override
@@ -464,6 +474,16 @@ public class AlbumDetailActivity extends AbsSlidingMusicPanelActivity implements
         @Override
         public Album loadInBackground() {
             return AlbumLoader.getAlbum(getContext(), albumId);
+        }
+    }
+
+    private void checkEnableSnowfall() {
+        SnowfallView snowfallView = findViewById(R.id.snowfall);
+        if (!PreferenceUtil.getInstance(this).getEnableSnowfall()) {
+            snowfallView.setVisibility(View.GONE);
+        } else {
+            snowfallView.setVisibility(View.VISIBLE);
+            snowfallView.bringToFront();
         }
     }
 }

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/activities/ArtistDetailActivity.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/activities/ArtistDetailActivity.java
@@ -26,6 +26,7 @@ import com.afollestad.materialdialogs.MaterialDialog;
 import com.afollestad.materialdialogs.util.DialogUtils;
 import com.bumptech.glide.Glide;
 import com.github.ksoichiro.android.observablescrollview.ObservableListView;
+import com.jetradarmobile.snowfall.SnowfallView;
 import com.kabouzeid.appthemehelper.util.ColorUtil;
 import com.kabouzeid.appthemehelper.util.MaterialValueHelper;
 import com.kabouzeid.gramophone.R;
@@ -123,6 +124,13 @@ public class ArtistDetailActivity extends AbsSlidingMusicPanelActivity implement
         setUpToolbar();
 
         getSupportLoaderManager().initLoader(LOADER_ID, getIntent().getExtras(), this);
+        checkEnableSnowfall();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        checkEnableSnowfall();
     }
 
     @Override
@@ -484,6 +492,16 @@ public class ArtistDetailActivity extends AbsSlidingMusicPanelActivity implement
         @Override
         public Artist loadInBackground() {
             return ArtistLoader.getArtist(getContext(), artistId);
+        }
+    }
+
+    private void checkEnableSnowfall() {
+        SnowfallView snowfallView = findViewById(R.id.snowfall);
+        if (!PreferenceUtil.getInstance(this).getEnableSnowfall()) {
+            snowfallView.setVisibility(View.GONE);
+        } else {
+            snowfallView.setVisibility(View.VISIBLE);
+            snowfallView.bringToFront();
         }
     }
 }

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/activities/GenreDetailActivity.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/activities/GenreDetailActivity.java
@@ -15,6 +15,7 @@ import android.widget.TextView;
 
 import com.afollestad.materialcab.MaterialCab;
 import com.h6ah4i.android.widget.advrecyclerview.utils.WrapperAdapterUtils;
+import com.jetradarmobile.snowfall.SnowfallView;
 import com.kabouzeid.appthemehelper.ThemeStore;
 import com.kabouzeid.gramophone.R;
 import com.kabouzeid.gramophone.adapter.song.SongAdapter;
@@ -27,6 +28,7 @@ import com.kabouzeid.gramophone.model.Genre;
 import com.kabouzeid.gramophone.model.Song;
 import com.kabouzeid.gramophone.ui.activities.base.AbsSlidingMusicPanelActivity;
 import com.kabouzeid.gramophone.util.PhonographColorUtil;
+import com.kabouzeid.gramophone.util.PreferenceUtil;
 import com.kabouzeid.gramophone.util.ViewUtil;
 import com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView;
 
@@ -73,6 +75,8 @@ public class GenreDetailActivity extends AbsSlidingMusicPanelActivity implements
         setUpToolBar();
 
         getSupportLoaderManager().initLoader(LOADER_ID, null, this);
+
+        checkEnableSnowfall();
     }
 
     @Override
@@ -174,6 +178,12 @@ public class GenreDetailActivity extends AbsSlidingMusicPanelActivity implements
     }
 
     @Override
+    protected void onResume() {
+        super.onResume();
+        checkEnableSnowfall();
+    }
+
+    @Override
     public Loader<ArrayList<Song>> onCreateLoader(int id, Bundle args) {
         return new GenreDetailActivity.AsyncGenreSongLoader(this, genre);
     }
@@ -201,6 +211,16 @@ public class GenreDetailActivity extends AbsSlidingMusicPanelActivity implements
         @Override
         public ArrayList<Song> loadInBackground() {
             return GenreLoader.getSongs(getContext(), genre.id);
+        }
+    }
+
+    private void checkEnableSnowfall() {
+        SnowfallView snowfallView = findViewById(R.id.snowfall);
+        if (!PreferenceUtil.getInstance(this).getEnableSnowfall()) {
+            snowfallView.setVisibility(View.GONE);
+        } else {
+            snowfallView.setVisibility(View.VISIBLE);
+            snowfallView.bringToFront();
         }
     }
 }

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/activities/MainActivity.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/activities/MainActivity.java
@@ -25,6 +25,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.bumptech.glide.Glide;
+import com.jetradarmobile.snowfall.SnowfallView;
 import com.kabouzeid.appthemehelper.ThemeStore;
 import com.kabouzeid.appthemehelper.util.ATHUtil;
 import com.kabouzeid.appthemehelper.util.NavigationViewUtil;
@@ -107,6 +108,14 @@ public class MainActivity extends AbsSlidingMusicPanelActivity {
         if (!checkShowIntro()) {
             checkShowChangelog();
         }
+
+        checkEnableSnowfall();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        checkEnableSnowfall();
     }
 
     private void setMusicChooser(int key) {
@@ -410,6 +419,16 @@ public class MainActivity extends AbsSlidingMusicPanelActivity {
             e.printStackTrace();
         }
         return false;
+    }
+
+    private void checkEnableSnowfall() {
+        SnowfallView snowfallView = findViewById(R.id.snowfall);
+        if (!PreferenceUtil.getInstance(this).getEnableSnowfall()) {
+            snowfallView.setVisibility(View.GONE);
+        } else {
+            snowfallView.setVisibility(View.VISIBLE);
+            snowfallView.bringToFront();
+        }
     }
 
     public interface MainActivityFragmentCallbacks {

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/activities/PlaylistDetailActivity.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/activities/PlaylistDetailActivity.java
@@ -18,6 +18,7 @@ import com.h6ah4i.android.widget.advrecyclerview.animator.GeneralItemAnimator;
 import com.h6ah4i.android.widget.advrecyclerview.animator.RefactoredDefaultItemAnimator;
 import com.h6ah4i.android.widget.advrecyclerview.draggable.RecyclerViewDragDropManager;
 import com.h6ah4i.android.widget.advrecyclerview.utils.WrapperAdapterUtils;
+import com.jetradarmobile.snowfall.SnowfallView;
 import com.kabouzeid.appthemehelper.ThemeStore;
 import com.kabouzeid.gramophone.R;
 import com.kabouzeid.gramophone.adapter.song.OrderablePlaylistSongAdapter;
@@ -37,6 +38,7 @@ import com.kabouzeid.gramophone.model.Song;
 import com.kabouzeid.gramophone.ui.activities.base.AbsSlidingMusicPanelActivity;
 import com.kabouzeid.gramophone.util.PhonographColorUtil;
 import com.kabouzeid.gramophone.util.PlaylistsUtil;
+import com.kabouzeid.gramophone.util.PreferenceUtil;
 import com.kabouzeid.gramophone.util.ViewUtil;
 import com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView;
 
@@ -87,6 +89,14 @@ public class PlaylistDetailActivity extends AbsSlidingMusicPanelActivity impleme
         setUpToolbar();
 
         getSupportLoaderManager().initLoader(LOADER_ID, null, this);
+
+        checkEnableSnowfall();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        checkEnableSnowfall();
     }
 
     @Override
@@ -275,6 +285,16 @@ public class PlaylistDetailActivity extends AbsSlidingMusicPanelActivity impleme
                 //noinspection unchecked
                 return (ArrayList<Song>) (List) PlaylistSongLoader.getPlaylistSongList(getContext(), playlist.id);
             }
+        }
+    }
+
+    private void checkEnableSnowfall() {
+        SnowfallView snowfallView = findViewById(R.id.snowfall);
+        if (!PreferenceUtil.getInstance(this).getEnableSnowfall()) {
+            snowfallView.setVisibility(View.GONE);
+        } else {
+            snowfallView.setVisibility(View.VISIBLE);
+            snowfallView.bringToFront();
         }
     }
 }

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/activities/SettingsActivity.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/activities/SettingsActivity.java
@@ -38,6 +38,7 @@ import com.kabouzeid.gramophone.util.NavigationUtil;
 import com.kabouzeid.gramophone.util.PreferenceUtil;
 
 import java.util.Arrays;
+import java.util.Calendar;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -150,6 +151,10 @@ public class SettingsActivity extends AbsBaseActivity implements ColorChooserDia
         @Override
         public void onCreatePreferences(Bundle bundle, String s) {
             addPreferencesFromResource(R.xml.pref_general);
+            // If it's December, enable the snowflakes option
+            if (Calendar.getInstance().get(Calendar.MONTH) == 11) {
+                addPreferencesFromResource(R.xml.pref_snow);
+            }
             addPreferencesFromResource(R.xml.pref_colors);
             addPreferencesFromResource(R.xml.pref_notification);
             addPreferencesFromResource(R.xml.pref_now_playing_screen);

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/player/PlayerAlbumCoverFragment.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/player/PlayerAlbumCoverFragment.java
@@ -14,6 +14,7 @@ import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import com.jetradarmobile.snowfall.SnowfallView;
 import com.kabouzeid.gramophone.R;
 import com.kabouzeid.gramophone.adapter.AlbumCoverPagerAdapter;
 import com.kabouzeid.gramophone.helper.MusicPlayerRemote;
@@ -88,6 +89,13 @@ public class PlayerAlbumCoverFragment extends AbsMusicServiceFragment implements
         });
         progressViewUpdateHelper = new MusicProgressViewUpdateHelper(this, 500, 1000);
         progressViewUpdateHelper.start();
+        checkEnableSnowfall();
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        checkEnableSnowfall();
     }
 
     @Override
@@ -271,5 +279,19 @@ public class PlayerAlbumCoverFragment extends AbsMusicServiceFragment implements
         void onFavoriteToggled();
 
         void onToolbarToggled();
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    private void checkEnableSnowfall() {
+        try {
+            SnowfallView snowfallView = getView().findViewById(R.id.snowfall);
+            if (!PreferenceUtil.getInstance(getActivity().getApplicationContext()).getEnableSnowfall()) {
+                snowfallView.setVisibility(View.GONE);
+            } else {
+                snowfallView.setVisibility(View.VISIBLE);
+            }
+        } catch (NullPointerException npe) {
+            npe.printStackTrace();
+        }
     }
 }

--- a/app/src/main/java/com/kabouzeid/gramophone/util/PreferenceUtil.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/util/PreferenceUtil.java
@@ -13,6 +13,7 @@ import com.kabouzeid.gramophone.ui.fragments.mainactivity.folders.FoldersFragmen
 import com.kabouzeid.gramophone.ui.fragments.player.NowPlayingScreen;
 
 import java.io.File;
+import java.util.Calendar;
 
 public final class PreferenceUtil {
     public static final String GENERAL_THEME = "general_theme";
@@ -73,6 +74,8 @@ public final class PreferenceUtil {
     public static final String SYNCHRONIZED_LYRICS_SHOW = "synchronized_lyrics_show";
 
     public static final String INITIALIZED_BLACKLIST = "initialized_blacklist";
+
+    public static final String ENABLE_SNOWFALL = "enable_snowfall";
 
     private static PreferenceUtil sInstance;
 
@@ -425,5 +428,10 @@ public final class PreferenceUtil {
 
     public final boolean initializedBlacklist() {
         return mPreferences.getBoolean(INITIALIZED_BLACKLIST, false);
+    }
+
+    public final boolean getEnableSnowfall() {
+        // Only allow snowfall if it's December
+        return Calendar.getInstance().get(Calendar.MONTH) == 11 && mPreferences.getBoolean(ENABLE_SNOWFALL, true);
     }
 }

--- a/app/src/main/res/layout/activity_album_detail.xml
+++ b/app/src/main/res/layout/activity_album_detail.xml
@@ -2,7 +2,15 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <com.jetradarmobile.snowfall.SnowfallView
+        android:id="@+id/snowfall"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:snowflakesAlreadyFalling="true"
+        app:snowflakesNum="25" />
 
     <ImageView
         android:id="@+id/image"

--- a/app/src/main/res/layout/activity_artist_detail.xml
+++ b/app/src/main/res/layout/activity_artist_detail.xml
@@ -1,7 +1,15 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <com.jetradarmobile.snowfall.SnowfallView
+        android:id="@+id/snowfall"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:snowflakesAlreadyFalling="true"
+        app:snowflakesNum="25" />
 
     <ImageView
         android:id="@+id/image"

--- a/app/src/main/res/layout/activity_genre_detail.xml
+++ b/app/src/main/res/layout/activity_genre_detail.xml
@@ -3,8 +3,16 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:transitionGroup="true"
     tools:ignore="UnusedAttribute">
+
+    <com.jetradarmobile.snowfall.SnowfallView
+        android:id="@+id/snowfall"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:snowflakesAlreadyFalling="true"
+        app:snowflakesNum="25" />
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_main_content.xml
+++ b/app/src/main/res/layout/activity_main_content.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/fragment_container"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" />
+    android:layout_height="match_parent">
+
+    <com.jetradarmobile.snowfall.SnowfallView
+        android:id="@+id/snowfall"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:snowflakesAlreadyFalling="true"
+        app:snowflakesNum="50" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/activity_playlist_detail.xml
+++ b/app/src/main/res/layout/activity_playlist_detail.xml
@@ -3,8 +3,16 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:transitionGroup="true"
     tools:ignore="UnusedAttribute">
+
+    <com.jetradarmobile.snowfall.SnowfallView
+        android:id="@+id/snowfall"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:snowflakesAlreadyFalling="true"
+        app:snowflakesNum="25" />
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_player_album_cover.xml
+++ b/app/src/main/res/layout/fragment_player_album_cover.xml
@@ -10,6 +10,13 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
+    <com.jetradarmobile.snowfall.SnowfallView
+        android:id="@+id/snowfall"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:snowflakesAlreadyFalling="true"
+        app:snowflakesNum="50"/>
+
     <FrameLayout
         android:id="@+id/player_lyrics"
         android:layout_width="match_parent"

--- a/app/src/main/res/raw/notices.xml
+++ b/app/src/main/res/raw/notices.xml
@@ -47,6 +47,12 @@
         <license>Apache Software License 2.0</license>
     </notice>
     <notice>
+        <name>Android Snowfall</name>
+        <url>https://github.com/JetradarMobile/android-snowfall</url>
+        <copyright>Copyright 2016 JetRadar</copyright>
+        <license>Apache Software License 2.0</license>
+    </notice>
+    <notice>
         <name>Android Support Libraries</name>
         <url>http://developer.android.com/tools/support-library/index.html</url>
         <copyright>Copyright (C) 2016 The Android Open Source Project</copyright>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,6 +118,7 @@
     <string name="pref_title_general_theme">General theme</string>
     <string name="pref_header_audio">Audio</string>
     <string name="pref_header_general">General</string>
+    <string name="pref_header_snowfall">Snowfall</string>
     <string name="pref_header_images">Images</string>
     <string name="pref_header_lockscreen">Lockscreen</string>
     <string name="pref_header_playlists">Playlists</string>
@@ -135,6 +136,7 @@
     <string name="pref_title_audio_ducking">Reduce volume on focus loss</string>
     <string name="pref_title_last_added_interval">Last added playlist interval</string>
     <string name="pref_title_synchronized_lyrics_show">Show synchronized lyrics</string>
+    <string name="pref_title_enable_snowfall">Enable snowfall</string>
     <string name="no_equalizer">No equalizer found.</string>
     <string name="no_audio_ID">"Play a song first, then try again."</string>
     <string name="delete_action">Delete</string>
@@ -167,6 +169,7 @@
     <string name="pref_summary_colored_app_shortcuts">Colors the app shortcuts in the primary color.</string>
     <string name="pref_summary_audio_ducking">Notifications, navigation etc.</string>
     <string name="pref_summary_synchronized_lyrics_show">Currently only synchronized lyrics in LRC format are supported. Either embedded or as a separate file.</string>
+    <string name="pref_summary_enable_snowfall">Celebrate the festive season with some snowflakes sprinkled throughout the app.</string>
     <string name="could_not_download_album_cover">"Couldn\u2019t download a matching album cover."</string>
     <string name="search_hint">Search your library…</string>
     <string name="favorites">Favorites</string>

--- a/app/src/main/res/xml/pref_snow.xml
+++ b/app/src/main/res/xml/pref_snow.xml
@@ -1,0 +1,13 @@
+<android.support.v7.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <com.kabouzeid.appthemehelper.common.prefs.supportv7.ATEPreferenceCategory android:title="@string/pref_header_snowfall">
+
+        <com.kabouzeid.appthemehelper.common.prefs.supportv7.ATESwitchPreference
+            android:defaultValue="true"
+            android:key="enable_snowfall"
+            android:summary="@string/pref_summary_enable_snowfall"
+            android:title="@string/pref_title_enable_snowfall"/>
+
+    </com.kabouzeid.appthemehelper.common.prefs.supportv7.ATEPreferenceCategory>
+
+</android.support.v7.preference.PreferenceScreen>


### PR DESCRIPTION
- Sprinkled snow throughout the app, thanks to the [android-snowfall](https://github.com/JetradarMobile/android-snowfall) library.
- Kept to 25 snowflakes in some text-heavier activities for readability.
- Defaulted to 50 snowflakes on the main screen and on album art.
- Did not include snowflakes in non-music-playing activities.
- Toggle snowflakes with the amazing snowflake switch in settings.
- Snowflakes are seasonal - only available in December.
- Updated build tools version and some other dependencies.

I have tested this snowflake feature on my OnePlus 3. 