### PR TITLE
Add sleep timer support to playing notification

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -121,7 +121,12 @@
             android:name=".appshortcuts.AppShortcutLauncherActivity"
             android:launchMode="singleInstance"
             android:theme="@android:style/Theme.Translucent.NoTitleBar" />
-
+        <activity
+            android:name=".ui.activities.SleepTimerActivity"
+            android:excludeFromRecents="true"
+            android:launchMode="singleInstance"
+            android:theme="@style/Theme.AppCompat.Dialog">
+        </activity>
         <service
             android:name=".service.MusicService"
             android:enabled="true" />

--- a/app/src/main/java/com/kabouzeid/gramophone/dialogs/SleepTimerDialog.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/dialogs/SleepTimerDialog.java
@@ -46,6 +46,9 @@ public class SleepTimerDialog extends DialogFragment {
     public void onDismiss(DialogInterface dialog) {
         super.onDismiss(dialog);
         timerUpdater.cancel();
+        if (getActivity() instanceof DismissListener) {
+            ((DismissListener) getActivity()).onDismissed();
+        }
     }
 
     @NonNull
@@ -73,7 +76,7 @@ public class SleepTimerDialog extends DialogFragment {
                     PreferenceUtil.getInstance(getActivity()).setNextSleepTimerElapsedRealtime(nextSleepTimerElapsedTime);
                     AlarmManager am = (AlarmManager) getActivity().getSystemService(Context.ALARM_SERVICE);
                     am.set(AlarmManager.ELAPSED_REALTIME_WAKEUP, nextSleepTimerElapsedTime, pi);
-
+                    getActivity().sendBroadcast(new Intent(MusicService.SLEEP_TIMER_CHANGED));
                     Toast.makeText(getActivity(), getActivity().getResources().getString(R.string.sleep_timer_set, minutes), Toast.LENGTH_SHORT).show();
                 })
                 .onNeutral((dialog, which) -> {
@@ -85,6 +88,7 @@ public class SleepTimerDialog extends DialogFragment {
                         AlarmManager am = (AlarmManager) getActivity().getSystemService(Context.ALARM_SERVICE);
                         am.cancel(previous);
                         previous.cancel();
+                        getActivity().sendBroadcast(new Intent(MusicService.SLEEP_TIMER_CHANGED));
                         Toast.makeText(getActivity(), getActivity().getResources().getString(R.string.sleep_timer_canceled), Toast.LENGTH_SHORT).show();
                     }
                 })
@@ -171,5 +175,9 @@ public class SleepTimerDialog extends DialogFragment {
         public void onFinish() {
             materialDialog.setActionButton(DialogAction.NEUTRAL, null);
         }
+    }
+
+    public interface DismissListener {
+        void onDismissed();
     }
 }

--- a/app/src/main/java/com/kabouzeid/gramophone/dialogs/SleepTimerDialog.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/dialogs/SleepTimerDialog.java
@@ -24,6 +24,7 @@ import com.kabouzeid.gramophone.service.MusicService;
 import com.kabouzeid.gramophone.ui.activities.PurchaseActivity;
 import com.kabouzeid.gramophone.util.MusicUtil;
 import com.kabouzeid.gramophone.util.PreferenceUtil;
+import com.kabouzeid.gramophone.util.SleepTimerUtil;
 import com.triggertrap.seekarc.SeekArc;
 
 import butterknife.BindView;
@@ -70,7 +71,7 @@ public class SleepTimerDialog extends DialogFragment {
 
                     final int minutes = seekArcProgress;
 
-                    PendingIntent pi = makeTimerPendingIntent(PendingIntent.FLAG_CANCEL_CURRENT);
+                    PendingIntent pi = SleepTimerUtil.createTimer(getActivity());
 
                     final long nextSleepTimerElapsedTime = SystemClock.elapsedRealtime() + minutes * 60 * 1000;
                     PreferenceUtil.getInstance(getActivity()).setNextSleepTimerElapsedRealtime(nextSleepTimerElapsedTime);
@@ -83,7 +84,7 @@ public class SleepTimerDialog extends DialogFragment {
                     if (getActivity() == null) {
                         return;
                     }
-                    final PendingIntent previous = makeTimerPendingIntent(PendingIntent.FLAG_NO_CREATE);
+                    final PendingIntent previous = SleepTimerUtil.getCurrentTimer(getActivity());
                     if (previous != null) {
                         AlarmManager am = (AlarmManager) getActivity().getSystemService(Context.ALARM_SERVICE);
                         am.cancel(previous);
@@ -93,7 +94,7 @@ public class SleepTimerDialog extends DialogFragment {
                     }
                 })
                 .showListener(dialog -> {
-                    if (makeTimerPendingIntent(PendingIntent.FLAG_NO_CREATE) != null) {
+                    if (SleepTimerUtil.isTimerRunning(getActivity())) {
                         timerUpdater.start();
                     }
                 })
@@ -150,15 +151,6 @@ public class SleepTimerDialog extends DialogFragment {
 
     private void updateTimeDisplayTime() {
         timerDisplay.setText(seekArcProgress + " min");
-    }
-
-    private PendingIntent makeTimerPendingIntent(int flag) {
-        return PendingIntent.getService(getActivity(), 0, makeTimerIntent(), flag);
-    }
-
-    private Intent makeTimerIntent() {
-        return new Intent(getActivity(), MusicService.class)
-                .setAction(MusicService.ACTION_QUIT);
     }
 
     private class TimerUpdater extends CountDownTimer {

--- a/app/src/main/java/com/kabouzeid/gramophone/service/MusicService.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/service/MusicService.java
@@ -98,6 +98,7 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
     public static final String REPEAT_MODE_CHANGED = PHONOGRAPH_PACKAGE_NAME + ".repeatmodechanged";
     public static final String SHUFFLE_MODE_CHANGED = PHONOGRAPH_PACKAGE_NAME + ".shufflemodechanged";
     public static final String MEDIA_STORE_CHANGED = PHONOGRAPH_PACKAGE_NAME + ".mediastorechanged";
+    public static final String SLEEP_TIMER_CHANGED = PHONOGRAPH_PACKAGE_NAME + ".sleeptimerchanged";
 
     public static final String SAVED_POSITION = "POSITION";
     public static final String SAVED_POSITION_IN_TRACK = "POSITION_IN_TRACK";
@@ -167,6 +168,14 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
             }
         }
     };
+
+    private final BroadcastReceiver sleepTimerReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, @NonNull Intent intent) {
+            updateNotification();
+        }
+    };
+
     private ContentObserver mediaStoreObserver;
     private boolean notHandledMetaChangedForCurrentTrack;
 
@@ -201,6 +210,7 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
         uiThreadHandler = new Handler();
 
         registerReceiver(widgetIntentReceiver, new IntentFilter(APP_WIDGET_UPDATE));
+        registerReceiver(sleepTimerReceiver, new IntentFilter(SLEEP_TIMER_CHANGED));
 
         initNotification();
 
@@ -348,6 +358,7 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
     @Override
     public void onDestroy() {
         unregisterReceiver(widgetIntentReceiver);
+        unregisterReceiver(sleepTimerReceiver);
         if (becomingNoisyReceiverRegistered) {
             unregisterReceiver(becomingNoisyReceiver);
             becomingNoisyReceiverRegistered = false;

--- a/app/src/main/java/com/kabouzeid/gramophone/service/notification/PlayingNotification.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/service/notification/PlayingNotification.java
@@ -3,11 +3,16 @@ package com.kabouzeid.gramophone.service.notification;
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Intent;
 import android.os.Build;
 import android.support.annotation.RequiresApi;
 
 import com.kabouzeid.gramophone.R;
 import com.kabouzeid.gramophone.service.MusicService;
+import com.kabouzeid.gramophone.ui.activities.MainActivity;
+import com.kabouzeid.gramophone.ui.activities.SleepTimerActivity;
+import com.kabouzeid.gramophone.util.SleepTimerUtil;
 
 import static android.content.Context.NOTIFICATION_SERVICE;
 
@@ -39,6 +44,24 @@ public abstract class PlayingNotification {
         stopped = true;
         service.stopForeground(true);
         notificationManager.cancel(NOTIFICATION_ID);
+    }
+
+    PendingIntent clickAction() {
+        Intent intent = new Intent(service, MainActivity.class).setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        return PendingIntent.getActivity(service, 0, intent, 0);
+    }
+
+    PendingIntent playbackAction(final String action) {
+        Intent intent = new Intent(service, MusicService.class).setAction(action);
+        return PendingIntent.getService(service, 0, intent, 0);
+    }
+
+    PendingIntent deleteAction() {
+        return PendingIntent.getService(service, 0, SleepTimerUtil.getTimerAction(service), 0);
+    }
+
+    PendingIntent sleepTimerAction() {
+        return PendingIntent.getActivity(service, 0, new Intent(service, SleepTimerActivity.class), 0);
     }
 
     void updateNotifyModeAndPostNotification(Notification notification) {

--- a/app/src/main/java/com/kabouzeid/gramophone/service/notification/PlayingNotificationImpl24.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/service/notification/PlayingNotificationImpl24.java
@@ -1,5 +1,6 @@
 package com.kabouzeid.gramophone.service.notification;
 
+import android.app.Notification;
 import android.app.PendingIntent;
 import android.content.ComponentName;
 import android.content.Intent;
@@ -8,6 +9,8 @@ import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
+import android.os.SystemClock;
+import android.support.annotation.RequiresApi;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.media.app.NotificationCompat.MediaStyle;
 import android.support.v7.graphics.Palette;
@@ -17,6 +20,7 @@ import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.animation.GlideAnimation;
 import com.bumptech.glide.request.target.SimpleTarget;
 import com.kabouzeid.gramophone.R;
+import com.kabouzeid.gramophone.ui.activities.SleepTimerActivity;
 import com.kabouzeid.gramophone.glide.SongGlideRequest;
 import com.kabouzeid.gramophone.glide.palette.BitmapPaletteWrapper;
 import com.kabouzeid.gramophone.model.Song;
@@ -48,11 +52,8 @@ public class PlayingNotificationImpl24 extends PlayingNotification {
         Intent action = new Intent(service, MainActivity.class);
         action.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
         final PendingIntent clickIntent = PendingIntent.getActivity(service, 0, action, 0);
-
-        final ComponentName serviceName = new ComponentName(service, MusicService.class);
-        Intent intent = new Intent(MusicService.ACTION_QUIT);
-        intent.setComponent(serviceName);
-        final PendingIntent deleteIntent = PendingIntent.getService(service, 0, intent, 0);
+        final PendingIntent deleteIntent = PendingIntent.getService(service, 1, stopPlayingIntent(), 0);
+        PendingIntent sleepTimerIntent = PendingIntent.getActivity(service, 0, new Intent(service, SleepTimerActivity.class), 0);
 
         final int bigNotificationImageSize = service.getResources().getDimensionPixelSize(R.dimen.notification_big_image_size);
         service.runOnUiThread(() -> SongGlideRequest.Builder.from(Glide.with(service), song)
@@ -73,6 +74,64 @@ public class PlayingNotificationImpl24 extends PlayingNotification {
                     void update(Bitmap bitmap, int color) {
                         if (bitmap == null)
                             bitmap = BitmapFactory.decodeResource(service.getResources(), R.drawable.default_album_art);
+
+                        Notification notification;
+
+                        if (isSleepTimerActive()) {
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                                notification = getChronoNotification(bitmap, color);
+                            } else {
+                                notification = getLegacyNotification(bitmap, color);
+                            }
+                        } else {
+                            notification = getLegacyNotification(bitmap, color);
+                        }
+
+                        if (stopped)
+                            return; // notification has been stopped before loading was finished
+                        updateNotifyModeAndPostNotification(notification);
+                    }
+
+                    @RequiresApi(26)
+                    Notification getChronoNotification(Bitmap bitmap, int color) {
+                        long time = PreferenceUtil.getInstance(service).getNextSleepTimerElapsedRealTime();
+                        Notification.Action playPauseAction = new Notification.Action(playButtonResId,
+                                service.getString(R.string.action_play_pause),
+                                retrievePlaybackAction(ACTION_TOGGLE_PAUSE));
+                        Notification.Action previousAction = new Notification.Action(R.drawable.ic_skip_previous_white_24dp,
+                                service.getString(R.string.action_previous),
+                                retrievePlaybackAction(ACTION_REWIND));
+                        Notification.Action nextAction = new Notification.Action(R.drawable.ic_skip_next_white_24dp,
+                                service.getString(R.string.action_next),
+                                retrievePlaybackAction(ACTION_SKIP));
+                        Notification.Action sleepTimerAction = new Notification.Action(R.drawable.ic_timer_white_24dp,
+                                service.getString(R.string.action_sleep_timer),
+                                sleepTimerIntent);
+                        Notification.Builder builder = new Notification.Builder(service, NOTIFICATION_CHANNEL_ID)
+                                .setSmallIcon(R.drawable.ic_notification)
+                                .setLargeIcon(bitmap)
+                                .setContentIntent(clickIntent)
+                                .setDeleteIntent(deleteIntent)
+                                .setContentTitle(song.title)
+                                .setContentText(text)
+                                .setOngoing(isPlaying)
+                                .setShowWhen(isPlaying)
+                                .setUsesChronometer(true)
+                                .setChronometerCountDown(true)
+                                .setWhen(System.currentTimeMillis() + (time - SystemClock.elapsedRealtime()))
+                                .addAction(previousAction)
+                                .addAction(playPauseAction)
+                                .addAction(nextAction)
+                                .addAction(sleepTimerAction)
+                                .setStyle(new Notification.MediaStyle().setMediaSession((android.media.session.MediaSession.Token)service.getMediaSession().getSessionToken().getToken()).setShowActionsInCompactView(0, 1, 2));
+
+                        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.O && PreferenceUtil.getInstance(service).coloredNotification()) {
+                            builder.setColor(color);
+                        }
+                        return builder.build();
+                    }
+
+                    Notification getLegacyNotification(Bitmap bitmap, int color) {
                         NotificationCompat.Action playPauseAction = new NotificationCompat.Action(playButtonResId,
                                 service.getString(R.string.action_play_pause),
                                 retrievePlaybackAction(ACTION_TOGGLE_PAUSE));
@@ -82,6 +141,9 @@ public class PlayingNotificationImpl24 extends PlayingNotification {
                         NotificationCompat.Action nextAction = new NotificationCompat.Action(R.drawable.ic_skip_next_white_24dp,
                                 service.getString(R.string.action_next),
                                 retrievePlaybackAction(ACTION_SKIP));
+                        NotificationCompat.Action sleepTimerAction = new NotificationCompat.Action(R.drawable.ic_timer_white_24dp,
+                                service.getString(R.string.action_sleep_timer),
+                                sleepTimerIntent);
                         NotificationCompat.Builder builder = new NotificationCompat.Builder(service, NOTIFICATION_CHANNEL_ID)
                                 .setSmallIcon(R.drawable.ic_notification)
                                 .setLargeIcon(bitmap)
@@ -93,7 +155,8 @@ public class PlayingNotificationImpl24 extends PlayingNotification {
                                 .setShowWhen(false)
                                 .addAction(previousAction)
                                 .addAction(playPauseAction)
-                                .addAction(nextAction);
+                                .addAction(nextAction)
+                                .addAction(sleepTimerAction);
 
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                             builder.setStyle(new MediaStyle().setMediaSession(service.getMediaSession().getSessionToken()).setShowActionsInCompactView(0, 1, 2))
@@ -101,10 +164,7 @@ public class PlayingNotificationImpl24 extends PlayingNotification {
                             if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.O && PreferenceUtil.getInstance(service).coloredNotification())
                                 builder.setColor(color);
                         }
-
-                        if (stopped)
-                            return; // notification has been stopped before loading was finished
-                        updateNotifyModeAndPostNotification(builder.build());
+                        return builder.build();
                     }
                 }));
     }
@@ -114,5 +174,13 @@ public class PlayingNotificationImpl24 extends PlayingNotification {
         Intent intent = new Intent(action);
         intent.setComponent(serviceName);
         return PendingIntent.getService(service, 0, intent, 0);
+    }
+
+    private boolean isSleepTimerActive() {
+        return PendingIntent.getService(service, 0, stopPlayingIntent(), PendingIntent.FLAG_NO_CREATE) != null;
+    }
+
+    private Intent stopPlayingIntent() {
+        return new Intent(service, MusicService.class).setAction(MusicService.ACTION_QUIT);
     }
 }

--- a/app/src/main/java/com/kabouzeid/gramophone/service/notification/PlayingNotificationImpl24.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/service/notification/PlayingNotificationImpl24.java
@@ -2,17 +2,14 @@ package com.kabouzeid.gramophone.service.notification;
 
 import android.app.Notification;
 import android.app.PendingIntent;
-import android.content.ComponentName;
-import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.SystemClock;
+import android.support.annotation.NonNull;
 import android.support.annotation.RequiresApi;
-import android.support.v4.app.NotificationCompat;
-import android.support.v4.media.app.NotificationCompat.MediaStyle;
 import android.support.v7.graphics.Palette;
 import android.text.TextUtils;
 
@@ -20,18 +17,17 @@ import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.animation.GlideAnimation;
 import com.bumptech.glide.request.target.SimpleTarget;
 import com.kabouzeid.gramophone.R;
-import com.kabouzeid.gramophone.ui.activities.SleepTimerActivity;
 import com.kabouzeid.gramophone.glide.SongGlideRequest;
 import com.kabouzeid.gramophone.glide.palette.BitmapPaletteWrapper;
 import com.kabouzeid.gramophone.model.Song;
-import com.kabouzeid.gramophone.service.MusicService;
-import com.kabouzeid.gramophone.ui.activities.MainActivity;
 import com.kabouzeid.gramophone.util.PreferenceUtil;
+import com.kabouzeid.gramophone.util.SleepTimerUtil;
 
 import static com.kabouzeid.gramophone.service.MusicService.ACTION_REWIND;
 import static com.kabouzeid.gramophone.service.MusicService.ACTION_SKIP;
 import static com.kabouzeid.gramophone.service.MusicService.ACTION_TOGGLE_PAUSE;
 
+@RequiresApi(24)
 public class PlayingNotificationImpl24 extends PlayingNotification {
 
     @Override
@@ -49,11 +45,9 @@ public class PlayingNotificationImpl24 extends PlayingNotification {
         final int playButtonResId = isPlaying
                 ? R.drawable.ic_pause_white_24dp : R.drawable.ic_play_arrow_white_24dp;
 
-        Intent action = new Intent(service, MainActivity.class);
-        action.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
-        final PendingIntent clickIntent = PendingIntent.getActivity(service, 0, action, 0);
-        final PendingIntent deleteIntent = PendingIntent.getService(service, 1, stopPlayingIntent(), 0);
-        PendingIntent sleepTimerIntent = PendingIntent.getActivity(service, 0, new Intent(service, SleepTimerActivity.class), 0);
+        final PendingIntent clickIntent = clickAction();
+        final PendingIntent deleteIntent = deleteAction();
+        PendingIntent sleepTimerIntent = sleepTimerAction();
 
         final int bigNotificationImageSize = service.getResources().getDimensionPixelSize(R.dimen.notification_big_image_size);
         service.runOnUiThread(() -> SongGlideRequest.Builder.from(Glide.with(service), song)
@@ -74,40 +68,21 @@ public class PlayingNotificationImpl24 extends PlayingNotification {
                     void update(Bitmap bitmap, int color) {
                         if (bitmap == null)
                             bitmap = BitmapFactory.decodeResource(service.getResources(), R.drawable.default_album_art);
-
-                        Notification notification;
-
-                        if (isSleepTimerActive()) {
-                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                                notification = getChronoNotification(bitmap, color);
-                            } else {
-                                notification = getLegacyNotification(bitmap, color);
-                            }
-                        } else {
-                            notification = getLegacyNotification(bitmap, color);
-                        }
-
-                        if (stopped)
-                            return; // notification has been stopped before loading was finished
-                        updateNotifyModeAndPostNotification(notification);
-                    }
-
-                    @RequiresApi(26)
-                    Notification getChronoNotification(Bitmap bitmap, int color) {
                         long time = PreferenceUtil.getInstance(service).getNextSleepTimerElapsedRealTime();
+                        boolean sleepTimer = SleepTimerUtil.isTimerRunning(service);
                         Notification.Action playPauseAction = new Notification.Action(playButtonResId,
                                 service.getString(R.string.action_play_pause),
-                                retrievePlaybackAction(ACTION_TOGGLE_PAUSE));
+                                playbackAction(ACTION_TOGGLE_PAUSE));
                         Notification.Action previousAction = new Notification.Action(R.drawable.ic_skip_previous_white_24dp,
                                 service.getString(R.string.action_previous),
-                                retrievePlaybackAction(ACTION_REWIND));
+                                playbackAction(ACTION_REWIND));
                         Notification.Action nextAction = new Notification.Action(R.drawable.ic_skip_next_white_24dp,
                                 service.getString(R.string.action_next),
-                                retrievePlaybackAction(ACTION_SKIP));
+                                playbackAction(ACTION_SKIP));
                         Notification.Action sleepTimerAction = new Notification.Action(R.drawable.ic_timer_white_24dp,
                                 service.getString(R.string.action_sleep_timer),
                                 sleepTimerIntent);
-                        Notification.Builder builder = new Notification.Builder(service, NOTIFICATION_CHANNEL_ID)
+                        Notification.Builder builder = builder()
                                 .setSmallIcon(R.drawable.ic_notification)
                                 .setLargeIcon(bitmap)
                                 .setContentIntent(clickIntent)
@@ -115,10 +90,10 @@ public class PlayingNotificationImpl24 extends PlayingNotification {
                                 .setContentTitle(song.title)
                                 .setContentText(text)
                                 .setOngoing(isPlaying)
-                                .setShowWhen(isPlaying)
+                                .setShowWhen(sleepTimer)
                                 .setUsesChronometer(true)
                                 .setChronometerCountDown(true)
-                                .setWhen(System.currentTimeMillis() + (time - SystemClock.elapsedRealtime()))
+                                .setWhen(sleepTimer ? System.currentTimeMillis() + (time - SystemClock.elapsedRealtime()) : 0)
                                 .addAction(previousAction)
                                 .addAction(playPauseAction)
                                 .addAction(nextAction)
@@ -128,59 +103,19 @@ public class PlayingNotificationImpl24 extends PlayingNotification {
                         if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.O && PreferenceUtil.getInstance(service).coloredNotification()) {
                             builder.setColor(color);
                         }
-                        return builder.build();
-                    }
 
-                    Notification getLegacyNotification(Bitmap bitmap, int color) {
-                        NotificationCompat.Action playPauseAction = new NotificationCompat.Action(playButtonResId,
-                                service.getString(R.string.action_play_pause),
-                                retrievePlaybackAction(ACTION_TOGGLE_PAUSE));
-                        NotificationCompat.Action previousAction = new NotificationCompat.Action(R.drawable.ic_skip_previous_white_24dp,
-                                service.getString(R.string.action_previous),
-                                retrievePlaybackAction(ACTION_REWIND));
-                        NotificationCompat.Action nextAction = new NotificationCompat.Action(R.drawable.ic_skip_next_white_24dp,
-                                service.getString(R.string.action_next),
-                                retrievePlaybackAction(ACTION_SKIP));
-                        NotificationCompat.Action sleepTimerAction = new NotificationCompat.Action(R.drawable.ic_timer_white_24dp,
-                                service.getString(R.string.action_sleep_timer),
-                                sleepTimerIntent);
-                        NotificationCompat.Builder builder = new NotificationCompat.Builder(service, NOTIFICATION_CHANNEL_ID)
-                                .setSmallIcon(R.drawable.ic_notification)
-                                .setLargeIcon(bitmap)
-                                .setContentIntent(clickIntent)
-                                .setDeleteIntent(deleteIntent)
-                                .setContentTitle(song.title)
-                                .setContentText(text)
-                                .setOngoing(isPlaying)
-                                .setShowWhen(false)
-                                .addAction(previousAction)
-                                .addAction(playPauseAction)
-                                .addAction(nextAction)
-                                .addAction(sleepTimerAction);
-
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                            builder.setStyle(new MediaStyle().setMediaSession(service.getMediaSession().getSessionToken()).setShowActionsInCompactView(0, 1, 2))
-                                    .setVisibility(NotificationCompat.VISIBILITY_PUBLIC);
-                            if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.O && PreferenceUtil.getInstance(service).coloredNotification())
-                                builder.setColor(color);
-                        }
-                        return builder.build();
+                        if (stopped)
+                            return; // notification has been stopped before loading was finished
+                        updateNotifyModeAndPostNotification(builder.build());
                     }
                 }));
     }
 
-    private PendingIntent retrievePlaybackAction(final String action) {
-        final ComponentName serviceName = new ComponentName(service, MusicService.class);
-        Intent intent = new Intent(action);
-        intent.setComponent(serviceName);
-        return PendingIntent.getService(service, 0, intent, 0);
-    }
-
-    private boolean isSleepTimerActive() {
-        return PendingIntent.getService(service, 0, stopPlayingIntent(), PendingIntent.FLAG_NO_CREATE) != null;
-    }
-
-    private Intent stopPlayingIntent() {
-        return new Intent(service, MusicService.class).setAction(MusicService.ACTION_QUIT);
+    @NonNull
+    private Notification.Builder builder() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            return new Notification.Builder(service, NOTIFICATION_CHANNEL_ID);
+        }
+        return new Notification.Builder(service);
     }
 }

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/activities/SleepTimerActivity.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/activities/SleepTimerActivity.java
@@ -1,0 +1,45 @@
+package com.kabouzeid.gramophone.ui.activities;
+
+import android.os.Bundle;
+
+import android.support.annotation.Nullable;
+
+import com.afollestad.materialdialogs.Theme;
+import com.kabouzeid.appthemehelper.ATHActivity;
+import com.kabouzeid.gramophone.R;
+import com.kabouzeid.gramophone.dialogs.SleepTimerDialog;
+import com.kabouzeid.gramophone.util.PreferenceUtil;
+
+
+public class SleepTimerActivity extends ATHActivity implements SleepTimerDialog.DismissListener {
+
+    @Override
+    public void onDismissed() {
+        finish();
+    }
+
+    @Override
+    protected int getThemeRes() {
+        // the SleepTimerDialog theme is chosen by the primary text color of the context. We
+        // therefore have to match the overall theme
+        return (getDialogTheme() == Theme.LIGHT)
+                ? R.style.Activity_Light_Dialog
+                : R.style.Activity_Dark_Dialog;
+    }
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        new SleepTimerDialog().show(getSupportFragmentManager(), "fragment_dialog");
+    }
+
+    private Theme getDialogTheme() {
+        switch (PreferenceUtil.getInstance(this).getTheme()) {
+            case "dark":
+            case "black":
+                return Theme.DARK;
+            default:
+                return Theme.LIGHT;
+        }
+    }
+}

--- a/app/src/main/java/com/kabouzeid/gramophone/util/PreferenceUtil.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/util/PreferenceUtil.java
@@ -106,7 +106,11 @@ public final class PreferenceUtil {
     }
 
     public int getGeneralTheme() {
-        return getThemeResFromPrefValue(mPreferences.getString(GENERAL_THEME, ""));
+        return getThemeResFromPrefValue(getTheme());
+    }
+
+    public String getTheme() {
+        return mPreferences.getString(GENERAL_THEME, "");
     }
 
     @StyleRes

--- a/app/src/main/java/com/kabouzeid/gramophone/util/SleepTimerUtil.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/util/SleepTimerUtil.java
@@ -1,0 +1,46 @@
+package com.kabouzeid.gramophone.util;
+
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.os.SystemClock;
+
+import com.kabouzeid.gramophone.service.MusicService;
+
+
+public class SleepTimerUtil {
+
+    public static PendingIntent createTimer(Context context) {
+        return makeTimerIntent(context, PendingIntent.FLAG_CANCEL_CURRENT);
+    }
+
+    public static Intent getTimerAction(Context context) {
+        return new Intent(context, MusicService.class).setAction(MusicService.ACTION_QUIT);
+    }
+
+    /**
+     * Returns the current sleep timer, if any.
+     * @param context the context.
+     * @return the current timer. Returns {@code null} if the sleep timer is not running.
+     */
+    public static PendingIntent getCurrentTimer(Context context) {
+        return makeTimerIntent(context, PendingIntent.FLAG_NO_CREATE);
+    }
+
+    public static boolean isTimerRunning(Context context) {
+        PendingIntent running = getCurrentTimer(context);
+
+        if (running != null) {
+            // AlarmManager does not seem to cancel intents after the alarm went off. We must
+            // therefore check  if it expired to determine whether the sleep timer is actually
+            // running
+            return PreferenceUtil.getInstance(context).getNextSleepTimerElapsedRealTime() - SystemClock.elapsedRealtime() > 0;
+        }
+
+        return false;
+    }
+
+    private static PendingIntent makeTimerIntent(Context context, int flag) {
+        return PendingIntent.getService(context, 110110110, getTimerAction(context), flag);
+    }
+}

--- a/app/src/main/res/layout/notification_big.xml
+++ b/app/src/main/res/layout/notification_big.xml
@@ -14,7 +14,7 @@
   ~ limitations under the License
   -->
 
-<!-- Layout to be used with only max 3 actions. It has a much larger picture at the left side-->
+<!-- Layout to be used with only max 4 actions. It has a much larger picture at the left side-->
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
@@ -29,18 +29,6 @@
         android:scaleType="centerCrop"
         tools:ignore="ContentDescription" />
 
-    <ImageButton
-        android:id="@+id/action_quit"
-        android:layout_width="36dp"
-        android:layout_height="36dp"
-        android:layout_alignParentEnd="true"
-        android:layout_alignParentRight="true"
-        android:layout_margin="2dp"
-        android:background="@drawable/notification_selector"
-        android:padding="6dp"
-        android:scaleType="fitCenter"
-        tools:ignore="ContentDescription" />
-
     <LinearLayout
         android:id="@+id/media_titles"
         android:layout_width="match_parent"
@@ -48,11 +36,11 @@
         android:layout_marginBottom="8dp"
         android:layout_marginLeft="12dp"
         android:layout_marginStart="12dp"
+        android:layout_marginRight="12dp"
+        android:layout_marginEnd="12dp"
         android:layout_marginTop="8dp"
         android:layout_toEndOf="@id/image"
-        android:layout_toLeftOf="@id/action_quit"
         android:layout_toRightOf="@id/image"
-        android:layout_toStartOf="@id/action_quit"
         android:minHeight="@dimen/notification_large_icon_height"
         android:orientation="vertical">
 
@@ -66,17 +54,37 @@
             android:singleLine="true"
             android:textAppearance="@style/Theme.Phonograph.Notification.Title" />
 
-        <TextView
-            android:id="@+id/text"
+        <GridLayout
+            android:id="@+id/sleep_group"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="-1dp"
-            android:layout_marginTop="-1dp"
-            android:layout_weight="1"
-            android:ellipsize="marquee"
-            android:fadingEdge="horizontal"
-            android:singleLine="true"
-            android:textAppearance="@style/Theme.Phonograph.Notification" />
+            android:layout_gravity="fill"
+            android:columnCount="2"
+            android:rowCount="1">
+                <TextView
+                    android:id="@+id/text"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="-1dp"
+                    android:layout_marginTop="-1dp"
+                    android:ellipsize="marquee"
+                    android:singleLine="true"
+                    android:layout_gravity="fill"
+                    android:textAppearance="@style/Theme.Phonograph.Notification" />
+                <TextView
+                    android:id="@+id/sleep_timer"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="-1dp"
+                    android:layout_marginLeft="0dp"
+                    android:layout_marginStart="0dp"
+                    android:layout_marginTop="-1dp"
+                    android:clickable="false"
+                    android:singleLine="true"
+                    android:textAlignment="textEnd"
+                    android:gravity="end"
+                    android:textAppearance="@style/Theme.Phonograph.Notification" />
+        </GridLayout>
 
         <TextView
             android:id="@+id/text2"
@@ -135,6 +143,20 @@
 
         <ImageButton
             android:id="@+id/action_next"
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:layout_width="48dp"
+            android:layout_height="match_parent"
+            android:layout_marginLeft="2dp"
+            android:layout_marginRight="2dp"
+            android:layout_weight="1"
+            android:background="@drawable/notification_selector"
+            android:gravity="center"
+            android:padding="8dp"
+            android:scaleType="fitCenter"
+            tools:ignore="ContentDescription" />
+
+        <ImageButton
+            android:id="@+id/action_sleep_timer"
             style="@style/Widget.AppCompat.Button.Borderless"
             android:layout_width="48dp"
             android:layout_height="match_parent"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -37,4 +37,13 @@
         <item name="android:transitionName" tools:ignore="NewApi">toolbar</item>
     </style>
 
+    <style name="Activity.Light.Dialog" parent="Base.Theme.AppCompat.Dialog">
+        <item name="android:textColorPrimary">@android:color/black</item>
+        <item name="windowNoTitle">true</item>
+    </style>
+
+    <style name="Activity.Dark.Dialog" parent="Base.Theme.AppCompat.Dialog">
+        <item name="android:textColorPrimary">@android:color/white</item>
+        <item name="windowNoTitle">true</item>
+    </style>
 </resources>


### PR DESCRIPTION
Adds an action to display the sleep timer dialog to the playing notification.

For Nougat and later a countdown is displayed when the sleep timer is active. For earlier releases, only a textual hint is provided that is updated less frequently to save resources.

Fixes #380 