### PR TITLE
Move Pageindicator to current position

### DIFF
--- a/app/src/main/java/com/kabouzeid/gramophone/preferences/NowPlayingScreenPreferenceDialog.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/preferences/NowPlayingScreenPreferenceDialog.java
@@ -50,6 +50,7 @@ public class NowPlayingScreenPreferenceDialog extends DialogFragment implements 
 
         InkPageIndicator pageIndicator = ButterKnife.findById(view, R.id.page_indicator);
         pageIndicator.setViewPager(viewPager);
+        pageIndicator.onPageSelected(viewPager.getCurrentItem());
 
         return new MaterialDialog.Builder(getContext())
                 .title(R.string.pref_title_now_playing_screen_appearance)


### PR DESCRIPTION
The page indicator was stuck on the first page without knowing that the preference was changed. Now we let the page indicator know that we had a change of heart
This fixes #408 