### PR TITLE
FIX: Can't swich to previous track with long click

### DIFF
--- a/app/src/main/java/com/kabouzeid/gramophone/service/MusicService.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/service/MusicService.java
@@ -886,7 +886,7 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
     }
 
     public void back(boolean force) {
-        if (getSongProgressMillis() > 2000) {
+        if (getSongProgressMillis() > 5000) {
             seek(0);
         } else {
             playPreviousSong(force);


### PR DESCRIPTION
Many heatsets can switch track with long click on volume buttons. Two long clicks requires around 5 seconds. With 2 seconds soooo hard to do this.