### PR TITLE
Add "sort order" menu to library view

### DIFF
--- a/app/src/main/java/com/kabouzeid/gramophone/adapter/album/AlbumAdapter.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/adapter/album/AlbumAdapter.java
@@ -198,8 +198,7 @@ public class AlbumAdapter extends AbsMultiSelectAdapter<AlbumAdapter.ViewHolder,
                 sectionName = dataSet.get(position).getArtistName();
                 break;
             case SortOrder.AlbumSortOrder.ALBUM_YEAR:
-                sectionName = Integer.toString(dataSet.get(position).getYear());
-                break;
+                return Integer.toString(dataSet.get(position).getYear());
         }
 
         return MusicUtil.getSectionName(sectionName);

--- a/app/src/main/java/com/kabouzeid/gramophone/adapter/album/AlbumAdapter.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/adapter/album/AlbumAdapter.java
@@ -26,6 +26,8 @@ import com.kabouzeid.gramophone.model.Song;
 import com.kabouzeid.gramophone.util.MusicUtil;
 import com.kabouzeid.gramophone.util.NavigationUtil;
 import com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView;
+import com.kabouzeid.gramophone.util.PreferenceUtil;
+import com.kabouzeid.gramophone.helper.SortOrder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -186,7 +188,21 @@ public class AlbumAdapter extends AbsMultiSelectAdapter<AlbumAdapter.ViewHolder,
     @NonNull
     @Override
     public String getSectionName(int position) {
-        return MusicUtil.getSectionName(dataSet.get(position).getTitle());
+        @Nullable String sectionName = null;
+        switch (PreferenceUtil.getInstance(activity).getAlbumSortOrder()) {
+            case SortOrder.AlbumSortOrder.ALBUM_A_Z:
+            case SortOrder.AlbumSortOrder.ALBUM_Z_A:
+                sectionName = dataSet.get(position).getTitle();
+                break;
+            case SortOrder.AlbumSortOrder.ALBUM_ARTIST:
+                sectionName = dataSet.get(position).getArtistName();
+                break;
+            case SortOrder.AlbumSortOrder.ALBUM_YEAR:
+                sectionName = Integer.toString(dataSet.get(position).getYear());
+                break;
+        }
+
+        return MusicUtil.getSectionName(sectionName);
     }
 
     public class ViewHolder extends MediaEntryViewHolder {

--- a/app/src/main/java/com/kabouzeid/gramophone/adapter/artist/ArtistAdapter.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/adapter/artist/ArtistAdapter.java
@@ -19,12 +19,14 @@ import com.kabouzeid.gramophone.adapter.base.AbsMultiSelectAdapter;
 import com.kabouzeid.gramophone.adapter.base.MediaEntryViewHolder;
 import com.kabouzeid.gramophone.glide.ArtistGlideRequest;
 import com.kabouzeid.gramophone.glide.PhonographColoredTarget;
+import com.kabouzeid.gramophone.helper.SortOrder;
 import com.kabouzeid.gramophone.helper.menu.SongsMenuHelper;
 import com.kabouzeid.gramophone.interfaces.CabHolder;
 import com.kabouzeid.gramophone.model.Artist;
 import com.kabouzeid.gramophone.model.Song;
 import com.kabouzeid.gramophone.util.MusicUtil;
 import com.kabouzeid.gramophone.util.NavigationUtil;
+import com.kabouzeid.gramophone.util.PreferenceUtil;
 import com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView;
 
 import java.util.ArrayList;
@@ -173,7 +175,15 @@ public class ArtistAdapter extends AbsMultiSelectAdapter<ArtistAdapter.ViewHolde
     @NonNull
     @Override
     public String getSectionName(int position) {
-        return MusicUtil.getSectionName(dataSet.get(position).getName());
+        @Nullable String sectionName = null;
+        switch (PreferenceUtil.getInstance(activity).getArtistSortOrder()) {
+            case SortOrder.ArtistSortOrder.ARTIST_A_Z:
+            case SortOrder.ArtistSortOrder.ARTIST_Z_A:
+                sectionName = dataSet.get(position).getName();
+                break;
+        }
+
+        return MusicUtil.getSectionName(sectionName);
     }
 
     public class ViewHolder extends MediaEntryViewHolder {

--- a/app/src/main/java/com/kabouzeid/gramophone/adapter/song/SongAdapter.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/adapter/song/SongAdapter.java
@@ -190,24 +190,22 @@ public class SongAdapter extends AbsMultiSelectAdapter<SongAdapter.ViewHolder, S
             return "";
         }
 
-//        @Nullable String sectionName = null;
-//        switch (PreferenceUtil.getInstance(activity).getSongSortOrder()) {
-//            case SortOrder.SongSortOrder.SONG_A_Z:
-//            case SortOrder.SongSortOrder.SONG_Z_A:
-//                sectionName = dataSet.get(position).title;
-//                break;
-//            case SortOrder.SongSortOrder.SONG_ALBUM:
-//                sectionName = dataSet.get(position).albumName;
-//                break;
-//            case SortOrder.SongSortOrder.SONG_ARTIST:
-//                sectionName = dataSet.get(position).artistName;
-//                break;
-//            case SortOrder.SongSortOrder.SONG_YEAR:
-//                sectionName = Integer.toString(dataSet.get(position).year);
-//                break;
-//        }
+        @Nullable String sectionName = null;
+        switch (PreferenceUtil.getInstance(activity).getSongSortOrder()) {
+            case SortOrder.SongSortOrder.SONG_A_Z:
+            case SortOrder.SongSortOrder.SONG_Z_A:
+                sectionName = dataSet.get(position).title;
+                break;
+            case SortOrder.SongSortOrder.SONG_ALBUM:
+                sectionName = dataSet.get(position).albumName;
+                break;
+            case SortOrder.SongSortOrder.SONG_ARTIST:
+                sectionName = dataSet.get(position).artistName;
+                break;
+            case SortOrder.SongSortOrder.SONG_YEAR:
+                return Integer.toString(dataSet.get(position).year);
+        }
 
-        String sectionName = dataSet.get(position).title;
         return MusicUtil.getSectionName(sectionName);
     }
 

--- a/app/src/main/java/com/kabouzeid/gramophone/adapter/song/SongAdapter.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/adapter/song/SongAdapter.java
@@ -21,12 +21,14 @@ import com.kabouzeid.gramophone.adapter.base.MediaEntryViewHolder;
 import com.kabouzeid.gramophone.glide.PhonographColoredTarget;
 import com.kabouzeid.gramophone.glide.SongGlideRequest;
 import com.kabouzeid.gramophone.helper.MusicPlayerRemote;
+import com.kabouzeid.gramophone.helper.SortOrder;
 import com.kabouzeid.gramophone.helper.menu.SongMenuHelper;
 import com.kabouzeid.gramophone.helper.menu.SongsMenuHelper;
 import com.kabouzeid.gramophone.interfaces.CabHolder;
 import com.kabouzeid.gramophone.model.Song;
 import com.kabouzeid.gramophone.util.MusicUtil;
 import com.kabouzeid.gramophone.util.NavigationUtil;
+import com.kabouzeid.gramophone.util.PreferenceUtil;
 import com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView;
 
 import java.util.ArrayList;
@@ -184,7 +186,29 @@ public class SongAdapter extends AbsMultiSelectAdapter<SongAdapter.ViewHolder, S
     @NonNull
     @Override
     public String getSectionName(int position) {
-        return showSectionName ? MusicUtil.getSectionName(dataSet.get(position).title) : "";
+        if (!showSectionName) {
+            return "";
+        }
+
+//        @Nullable String sectionName = null;
+//        switch (PreferenceUtil.getInstance(activity).getSongSortOrder()) {
+//            case SortOrder.SongSortOrder.SONG_A_Z:
+//            case SortOrder.SongSortOrder.SONG_Z_A:
+//                sectionName = dataSet.get(position).title;
+//                break;
+//            case SortOrder.SongSortOrder.SONG_ALBUM:
+//                sectionName = dataSet.get(position).albumName;
+//                break;
+//            case SortOrder.SongSortOrder.SONG_ARTIST:
+//                sectionName = dataSet.get(position).artistName;
+//                break;
+//            case SortOrder.SongSortOrder.SONG_YEAR:
+//                sectionName = Integer.toString(dataSet.get(position).year);
+//                break;
+//        }
+
+        String sectionName = dataSet.get(position).title;
+        return MusicUtil.getSectionName(sectionName);
     }
 
     public class ViewHolder extends MediaEntryViewHolder {

--- a/app/src/main/java/com/kabouzeid/gramophone/helper/SortOrder.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/helper/SortOrder.java
@@ -60,7 +60,7 @@ public final class SortOrder {
                 + " DESC";
 
         /* Album sort order artist */
-        String ALBUM_ARTIST = MediaStore.Audio.Albums.ARTIST;
+        String ALBUM_ARTIST = MediaStore.Audio.Artists.DEFAULT_SORT_ORDER;
 
         /* Album sort order year */
         String ALBUM_YEAR = MediaStore.Audio.Albums.FIRST_YEAR + " DESC";
@@ -78,10 +78,10 @@ public final class SortOrder {
         String SONG_Z_A = SONG_A_Z + " DESC";
 
         /* Song sort order artist */
-        String SONG_ARTIST = MediaStore.Audio.Media.ARTIST;
+        String SONG_ARTIST = MediaStore.Audio.Artists.DEFAULT_SORT_ORDER;
 
         /* Song sort order album */
-        String SONG_ALBUM = MediaStore.Audio.Media.ALBUM;
+        String SONG_ALBUM = MediaStore.Audio.Albums.DEFAULT_SORT_ORDER;
 
         /* Song sort order year */
         String SONG_YEAR = MediaStore.Audio.Media.YEAR + " DESC";

--- a/app/src/main/java/com/kabouzeid/gramophone/helper/SortOrder.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/helper/SortOrder.java
@@ -60,7 +60,8 @@ public final class SortOrder {
                 + " DESC";
 
         /* Album sort order artist */
-        String ALBUM_ARTIST = MediaStore.Audio.Artists.DEFAULT_SORT_ORDER;
+        String ALBUM_ARTIST = MediaStore.Audio.Artists.DEFAULT_SORT_ORDER
+                + ", " + MediaStore.Audio.Albums.DEFAULT_SORT_ORDER;
 
         /* Album sort order year */
         String ALBUM_YEAR = MediaStore.Audio.Albums.FIRST_YEAR + " DESC";

--- a/app/src/main/java/com/kabouzeid/gramophone/helper/SortOrder.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/helper/SortOrder.java
@@ -64,8 +64,7 @@ public final class SortOrder {
                 + ", " + MediaStore.Audio.Albums.DEFAULT_SORT_ORDER;
 
         /* Album sort order year */
-        String ALBUM_YEAR = MediaStore.Audio.Albums.FIRST_YEAR + " DESC";
-
+        String ALBUM_YEAR = MediaStore.Audio.Media.YEAR + " DESC";
     }
 
     /**

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/LibraryFragment.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/LibraryFragment.java
@@ -29,6 +29,7 @@ import com.kabouzeid.gramophone.R;
 import com.kabouzeid.gramophone.adapter.MusicLibraryPagerAdapter;
 import com.kabouzeid.gramophone.dialogs.CreatePlaylistDialog;
 import com.kabouzeid.gramophone.helper.MusicPlayerRemote;
+import com.kabouzeid.gramophone.helper.SortOrder;
 import com.kabouzeid.gramophone.interfaces.CabHolder;
 import com.kabouzeid.gramophone.loader.SongLoader;
 import com.kabouzeid.gramophone.ui.activities.MainActivity;
@@ -36,6 +37,8 @@ import com.kabouzeid.gramophone.ui.activities.SearchActivity;
 import com.kabouzeid.gramophone.ui.fragments.mainactivity.AbsMainActivityFragment;
 import com.kabouzeid.gramophone.ui.fragments.mainactivity.library.pager.AbsLibraryPagerRecyclerViewCustomGridSizeFragment;
 import com.kabouzeid.gramophone.ui.fragments.mainactivity.library.pager.PlaylistsFragment;
+import com.kabouzeid.gramophone.ui.fragments.mainactivity.library.pager.AlbumsFragment;
+import com.kabouzeid.gramophone.ui.fragments.mainactivity.library.pager.ArtistsFragment;
 import com.kabouzeid.gramophone.util.PhonographColorUtil;
 import com.kabouzeid.gramophone.util.PreferenceUtil;
 import com.kabouzeid.gramophone.util.Util;
@@ -197,6 +200,23 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
 
             menu.findItem(R.id.action_colored_footers).setChecked(absLibraryRecyclerViewCustomGridSizeFragment.usePalette());
             menu.findItem(R.id.action_colored_footers).setEnabled(absLibraryRecyclerViewCustomGridSizeFragment.canUsePalette());
+
+            if (currentFragment instanceof AlbumsFragment) {
+                SubMenu sortOrderMenu = menu.findItem(R.id.action_sort_order).getSubMenu();
+                String currentSortOrder = absLibraryRecyclerViewCustomGridSizeFragment.getSortOrder();
+                sortOrderMenu.clear();
+                sortOrderMenu.add(0, R.id.action_album_sort_asc, 0, R.string.sort_a_z).setChecked(currentSortOrder == SortOrder.AlbumSortOrder.ALBUM_A_Z);
+                sortOrderMenu.add(0, R.id.action_album_sort_desc, 1, R.string.sort_z_a).setChecked(currentSortOrder == SortOrder.AlbumSortOrder.ALBUM_Z_A);
+                sortOrderMenu.add(0, R.id.action_album_sort_artist, 2, R.string.sort_artist).setChecked(currentSortOrder == SortOrder.AlbumSortOrder.ALBUM_ARTIST);
+                sortOrderMenu.setGroupCheckable(0, true, true);
+            } else if (currentFragment instanceof ArtistsFragment) {
+                SubMenu sortOrderMenu = menu.findItem(R.id.action_sort_order).getSubMenu();
+                String currentSortOrder = absLibraryRecyclerViewCustomGridSizeFragment.getSortOrder();
+                sortOrderMenu.clear();
+                sortOrderMenu.add(0, R.id.action_artist_sort_asc, 0, R.string.sort_a_z).setChecked(currentSortOrder == SortOrder.ArtistSortOrder.ARTIST_A_Z);
+                sortOrderMenu.add(0, R.id.action_artist_sort_desc, 1, R.string.sort_z_a).setChecked(currentSortOrder == SortOrder.ArtistSortOrder.ARTIST_Z_A);
+                sortOrderMenu.setGroupCheckable(0, true, true);
+            }
         } else {
             menu.removeItem(R.id.action_grid_size);
             menu.removeItem(R.id.action_colored_footers);
@@ -226,6 +246,9 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
                 return true;
             }
             if (handleGridSizeMenuItem(absLibraryRecyclerViewCustomGridSizeFragment, item)) {
+                return true;
+            }
+            if (handleSortOrderMenuItem(absLibraryRecyclerViewCustomGridSizeFragment, item)) {
                 return true;
             }
         }
@@ -327,6 +350,40 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
             toolbar.getMenu().findItem(R.id.action_colored_footers).setEnabled(fragment.canUsePalette());
             return true;
         }
+        return false;
+    }
+
+    private boolean handleSortOrderMenuItem(@NonNull AbsLibraryPagerRecyclerViewCustomGridSizeFragment fragment, @NonNull MenuItem item) {
+        String sortOrder = null;
+        if (fragment instanceof AlbumsFragment) {
+            switch (item.getItemId()) {
+                case R.id.action_album_sort_asc:
+                    sortOrder = SortOrder.AlbumSortOrder.ALBUM_A_Z;
+                    break;
+                case R.id.action_album_sort_desc:
+                    sortOrder = SortOrder.AlbumSortOrder.ALBUM_Z_A;
+                    break;
+                case R.id.action_album_sort_artist:
+                    sortOrder = SortOrder.AlbumSortOrder.ALBUM_ARTIST;
+                    break;
+            }
+        } else if (fragment instanceof ArtistsFragment) {
+            switch (item.getItemId()) {
+                case R.id.action_artist_sort_asc:
+                    sortOrder = SortOrder.ArtistSortOrder.ARTIST_A_Z;
+                    break;
+                case R.id.action_artist_sort_desc:
+                    sortOrder = SortOrder.ArtistSortOrder.ARTIST_Z_A;
+                    break;
+            }
+        }
+
+        if (sortOrder != null) {
+            item.setChecked(true);
+            fragment.setAndSaveSortOrder(sortOrder);
+            return true;
+        }
+
         return false;
     }
 

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/LibraryFragment.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/LibraryFragment.java
@@ -201,25 +201,11 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
             menu.findItem(R.id.action_colored_footers).setChecked(absLibraryRecyclerViewCustomGridSizeFragment.usePalette());
             menu.findItem(R.id.action_colored_footers).setEnabled(absLibraryRecyclerViewCustomGridSizeFragment.canUsePalette());
 
-            if (currentFragment instanceof AlbumsFragment) {
-                SubMenu sortOrderMenu = menu.findItem(R.id.action_sort_order).getSubMenu();
-                String currentSortOrder = absLibraryRecyclerViewCustomGridSizeFragment.getSortOrder();
-                sortOrderMenu.clear();
-                sortOrderMenu.add(0, R.id.action_album_sort_asc, 0, R.string.sort_a_z).setChecked(currentSortOrder == SortOrder.AlbumSortOrder.ALBUM_A_Z);
-                sortOrderMenu.add(0, R.id.action_album_sort_desc, 1, R.string.sort_z_a).setChecked(currentSortOrder == SortOrder.AlbumSortOrder.ALBUM_Z_A);
-                sortOrderMenu.add(0, R.id.action_album_sort_artist, 2, R.string.sort_artist).setChecked(currentSortOrder == SortOrder.AlbumSortOrder.ALBUM_ARTIST);
-                sortOrderMenu.setGroupCheckable(0, true, true);
-            } else if (currentFragment instanceof ArtistsFragment) {
-                SubMenu sortOrderMenu = menu.findItem(R.id.action_sort_order).getSubMenu();
-                String currentSortOrder = absLibraryRecyclerViewCustomGridSizeFragment.getSortOrder();
-                sortOrderMenu.clear();
-                sortOrderMenu.add(0, R.id.action_artist_sort_asc, 0, R.string.sort_a_z).setChecked(currentSortOrder == SortOrder.ArtistSortOrder.ARTIST_A_Z);
-                sortOrderMenu.add(0, R.id.action_artist_sort_desc, 1, R.string.sort_z_a).setChecked(currentSortOrder == SortOrder.ArtistSortOrder.ARTIST_Z_A);
-                sortOrderMenu.setGroupCheckable(0, true, true);
-            }
+            setUpSortOrderMenu(absLibraryRecyclerViewCustomGridSizeFragment, menu.findItem(R.id.action_sort_order).getSubMenu());
         } else {
             menu.removeItem(R.id.action_grid_size);
             menu.removeItem(R.id.action_colored_footers);
+            menu.removeItem(R.id.action_sort_order);
         }
         Activity activity = getActivity();
         if (activity == null) return;
@@ -351,6 +337,27 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
             return true;
         }
         return false;
+    }
+
+    private void setUpSortOrderMenu(@NonNull AbsLibraryPagerRecyclerViewCustomGridSizeFragment fragment, @NonNull SubMenu sortOrderMenu) {
+        String currentSortOrder = fragment.getSortOrder();
+        sortOrderMenu.clear();
+
+        if (fragment instanceof AlbumsFragment) {
+            sortOrderMenu.add(0, R.id.action_album_sort_asc, 0, R.string.sort_a_z)
+                    .setChecked(currentSortOrder.equals(SortOrder.AlbumSortOrder.ALBUM_A_Z));
+            sortOrderMenu.add(0, R.id.action_album_sort_desc, 1, R.string.sort_z_a)
+                    .setChecked(currentSortOrder.equals(SortOrder.AlbumSortOrder.ALBUM_Z_A));
+            sortOrderMenu.add(0, R.id.action_album_sort_artist, 2, R.string.sort_artist)
+                    .setChecked(currentSortOrder.equals(SortOrder.AlbumSortOrder.ALBUM_ARTIST));
+        } else if (fragment instanceof ArtistsFragment) {
+            sortOrderMenu.add(0, R.id.action_artist_sort_asc, 0, R.string.sort_a_z)
+                    .setChecked(currentSortOrder.equals(SortOrder.ArtistSortOrder.ARTIST_A_Z));
+            sortOrderMenu.add(0, R.id.action_artist_sort_desc, 1, R.string.sort_z_a)
+                    .setChecked(currentSortOrder.equals(SortOrder.ArtistSortOrder.ARTIST_Z_A));
+        }
+
+        sortOrderMenu.setGroupCheckable(0, true, true);
     }
 
     private boolean handleSortOrderMenuItem(@NonNull AbsLibraryPagerRecyclerViewCustomGridSizeFragment fragment, @NonNull MenuItem item) {

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/LibraryFragment.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/LibraryFragment.java
@@ -39,6 +39,7 @@ import com.kabouzeid.gramophone.ui.fragments.mainactivity.library.pager.AbsLibra
 import com.kabouzeid.gramophone.ui.fragments.mainactivity.library.pager.PlaylistsFragment;
 import com.kabouzeid.gramophone.ui.fragments.mainactivity.library.pager.AlbumsFragment;
 import com.kabouzeid.gramophone.ui.fragments.mainactivity.library.pager.ArtistsFragment;
+import com.kabouzeid.gramophone.ui.fragments.mainactivity.library.pager.SongsFragment;
 import com.kabouzeid.gramophone.util.PhonographColorUtil;
 import com.kabouzeid.gramophone.util.PreferenceUtil;
 import com.kabouzeid.gramophone.util.Util;
@@ -350,11 +351,24 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
                     .setChecked(currentSortOrder.equals(SortOrder.AlbumSortOrder.ALBUM_Z_A));
             sortOrderMenu.add(0, R.id.action_album_sort_artist, 2, R.string.sort_artist)
                     .setChecked(currentSortOrder.equals(SortOrder.AlbumSortOrder.ALBUM_ARTIST));
+            sortOrderMenu.add(0, R.id.action_album_sort_year, 3, R.string.sort_year)
+                    .setChecked(currentSortOrder.equals(SortOrder.AlbumSortOrder.ALBUM_YEAR));
         } else if (fragment instanceof ArtistsFragment) {
             sortOrderMenu.add(0, R.id.action_artist_sort_asc, 0, R.string.sort_a_z)
                     .setChecked(currentSortOrder.equals(SortOrder.ArtistSortOrder.ARTIST_A_Z));
             sortOrderMenu.add(0, R.id.action_artist_sort_desc, 1, R.string.sort_z_a)
                     .setChecked(currentSortOrder.equals(SortOrder.ArtistSortOrder.ARTIST_Z_A));
+        } else if (fragment instanceof SongsFragment) {
+            sortOrderMenu.add(0, R.id.action_song_sort_asc, 0, R.string.sort_a_z)
+                    .setChecked(currentSortOrder.equals(SortOrder.SongSortOrder.SONG_A_Z));
+            sortOrderMenu.add(0, R.id.action_song_sort_desc, 1, R.string.sort_z_a)
+                    .setChecked(currentSortOrder.equals(SortOrder.SongSortOrder.SONG_Z_A));
+            sortOrderMenu.add(0, R.id.action_song_sort_artist, 2, R.string.sort_artist)
+                    .setChecked(currentSortOrder.equals(SortOrder.SongSortOrder.SONG_ARTIST));
+            sortOrderMenu.add(0, R.id.action_song_sort_album, 3, R.string.sort_album)
+                    .setChecked(currentSortOrder.equals(SortOrder.SongSortOrder.SONG_ALBUM));
+            sortOrderMenu.add(0, R.id.action_song_sort_year, 4, R.string.sort_year)
+                    .setChecked(currentSortOrder.equals(SortOrder.SongSortOrder.SONG_YEAR));
         }
 
         sortOrderMenu.setGroupCheckable(0, true, true);
@@ -373,6 +387,9 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
                 case R.id.action_album_sort_artist:
                     sortOrder = SortOrder.AlbumSortOrder.ALBUM_ARTIST;
                     break;
+                case R.id.action_album_sort_year:
+                    sortOrder = SortOrder.AlbumSortOrder.ALBUM_YEAR;
+                    break;
             }
         } else if (fragment instanceof ArtistsFragment) {
             switch (item.getItemId()) {
@@ -381,6 +398,24 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
                     break;
                 case R.id.action_artist_sort_desc:
                     sortOrder = SortOrder.ArtistSortOrder.ARTIST_Z_A;
+                    break;
+            }
+        } else if (fragment instanceof SongsFragment) {
+            switch (item.getItemId()) {
+                case R.id.action_song_sort_asc:
+                    sortOrder = SortOrder.SongSortOrder.SONG_A_Z;
+                    break;
+                case R.id.action_song_sort_desc:
+                    sortOrder = SortOrder.SongSortOrder.SONG_Z_A;
+                    break;
+                case R.id.action_song_sort_artist:
+                    sortOrder = SortOrder.SongSortOrder.SONG_ARTIST;
+                    break;
+                case R.id.action_song_sort_album:
+                    sortOrder = SortOrder.SongSortOrder.SONG_ALBUM;
+                    break;
+                case R.id.action_song_sort_year:
+                    sortOrder = SortOrder.SongSortOrder.SONG_YEAR;
                     break;
             }
         }

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/pager/AbsLibraryPagerRecyclerViewCustomGridSizeFragment.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/pager/AbsLibraryPagerRecyclerViewCustomGridSizeFragment.java
@@ -14,6 +14,7 @@ import com.kabouzeid.gramophone.util.Util;
  */
 public abstract class AbsLibraryPagerRecyclerViewCustomGridSizeFragment<A extends RecyclerView.Adapter, LM extends RecyclerView.LayoutManager> extends AbsLibraryPagerRecyclerViewFragment<A, LM> {
     private int gridSize;
+    private String sortOrder;
 
     private boolean usePaletteInitialized;
     private boolean usePalette;
@@ -49,6 +50,13 @@ public abstract class AbsLibraryPagerRecyclerViewCustomGridSizeFragment<A extend
         return usePalette;
     }
 
+    public final String getSortOrder() {
+        if (sortOrder == null) {
+            sortOrder = loadSortOrder();
+        }
+        return sortOrder;
+    }
+
     public void setAndSaveGridSize(final int gridSize) {
         int oldLayoutRes = getItemLayoutRes();
         this.gridSize = gridSize;
@@ -70,6 +78,11 @@ public abstract class AbsLibraryPagerRecyclerViewCustomGridSizeFragment<A extend
         this.usePalette = usePalette;
         saveUsePalette(usePalette);
         setUsePalette(usePalette);
+    }
+
+    public void setAndSaveSortOrder(final String sortOrder) {
+        this.sortOrder = sortOrder;
+        saveSortOrder(sortOrder);
     }
 
     /**
@@ -131,6 +144,10 @@ public abstract class AbsLibraryPagerRecyclerViewCustomGridSizeFragment<A extend
     protected abstract void setUsePalette(boolean usePalette);
 
     protected abstract void setGridSize(int gridSize);
+
+    protected abstract String loadSortOrder();
+
+    protected abstract void saveSortOrder(String sortOrder);
 
     protected int getMaxGridSizeForList() {
         if (isLandscape()) {

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/pager/AlbumsFragment.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/pager/AlbumsFragment.java
@@ -56,6 +56,18 @@ public class AlbumsFragment extends AbsLibraryPagerRecyclerViewCustomGridSizeFra
     }
 
     @Override
+    protected String loadSortOrder() {
+        return PreferenceUtil.getInstance(getActivity()).getAlbumSortOrder();
+    }
+
+    @Override
+    protected void saveSortOrder(String sortOrder) {
+        PreferenceUtil.getInstance(getActivity()).setAlbumSortOrder(sortOrder);
+        onMediaStoreChanged();
+        getAdapter().notifyDataSetChanged();
+    }
+
+    @Override
     public boolean loadUsePalette() {
         return PreferenceUtil.getInstance(getActivity()).albumColoredFooters();
     }

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/pager/ArtistsFragment.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/pager/ArtistsFragment.java
@@ -63,6 +63,18 @@ public class ArtistsFragment extends AbsLibraryPagerRecyclerViewCustomGridSizeFr
     }
 
     @Override
+    protected String loadSortOrder() {
+        return PreferenceUtil.getInstance(getActivity()).getArtistSortOrder();
+    }
+
+    @Override
+    protected void saveSortOrder(String sortOrder) {
+        PreferenceUtil.getInstance(getActivity()).setArtistSortOrder(sortOrder);
+        onMediaStoreChanged();
+        getAdapter().notifyDataSetChanged();
+    }
+
+    @Override
     protected int loadGridSize() {
         return PreferenceUtil.getInstance(getActivity()).getArtistGridSize(getActivity());
     }

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/pager/SongsFragment.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/pager/SongsFragment.java
@@ -74,6 +74,16 @@ public class SongsFragment extends AbsLibraryPagerRecyclerViewCustomGridSizeFrag
     }
 
     @Override
+    protected String loadSortOrder() {
+        return PreferenceUtil.getInstance(getActivity()).getSongSortOrder();
+    }
+
+    @Override
+    protected void saveSortOrder(String sortOrder) {
+        //PreferenceUtil.getInstance(getActivity()).setSongSortOrder(sortOrder);
+    }
+
+    @Override
     protected int loadGridSize() {
         return PreferenceUtil.getInstance(getActivity()).getSongGridSize(getActivity());
     }

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/pager/SongsFragment.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/pager/SongsFragment.java
@@ -80,7 +80,9 @@ public class SongsFragment extends AbsLibraryPagerRecyclerViewCustomGridSizeFrag
 
     @Override
     protected void saveSortOrder(String sortOrder) {
-        //PreferenceUtil.getInstance(getActivity()).setSongSortOrder(sortOrder);
+        PreferenceUtil.getInstance(getActivity()).setSongSortOrder(sortOrder);
+        onMediaStoreChanged();
+        getAdapter().notifyDataSetChanged();
     }
 
     @Override

--- a/app/src/main/java/com/kabouzeid/gramophone/util/PreferenceUtil.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/util/PreferenceUtil.java
@@ -222,6 +222,12 @@ public final class PreferenceUtil {
         return mPreferences.getString(ARTIST_SORT_ORDER, SortOrder.ArtistSortOrder.ARTIST_A_Z);
     }
 
+    public void setArtistSortOrder(final String sortOrder) {
+        final SharedPreferences.Editor editor = mPreferences.edit();
+        editor.putString(ARTIST_SORT_ORDER, sortOrder);
+        editor.apply();
+    }
+
     public final String getArtistSongSortOrder() {
         return mPreferences.getString(ARTIST_SONG_SORT_ORDER, SortOrder.ArtistSongSortOrder.SONG_A_Z);
     }
@@ -232,6 +238,12 @@ public final class PreferenceUtil {
 
     public final String getAlbumSortOrder() {
         return mPreferences.getString(ALBUM_SORT_ORDER, SortOrder.AlbumSortOrder.ALBUM_A_Z);
+    }
+
+    public void setAlbumSortOrder(final String sortOrder) {
+        final SharedPreferences.Editor editor = mPreferences.edit();
+        editor.putString(ALBUM_SORT_ORDER, sortOrder);
+        editor.apply();
     }
 
     public final String getAlbumSongSortOrder() {

--- a/app/src/main/java/com/kabouzeid/gramophone/util/PreferenceUtil.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/util/PreferenceUtil.java
@@ -254,6 +254,12 @@ public final class PreferenceUtil {
         return mPreferences.getString(SONG_SORT_ORDER, SortOrder.SongSortOrder.SONG_A_Z);
     }
 
+    public void setSongSortOrder(final String sortOrder) {
+        final SharedPreferences.Editor editor = mPreferences.edit();
+        editor.putString(SONG_SORT_ORDER, sortOrder);
+        editor.apply();
+    }
+
     public final String getGenreSortOrder() {
         return mPreferences.getString(GENRE_SORT_ORDER, SortOrder.GenreSortOrder.GENRE_A_Z);
     }

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -51,6 +51,13 @@
     </item>
 
     <item
+        android:id="@+id/action_sort_order"
+        android:title="@string/action_sort">
+        <menu>
+        </menu>
+    </item>
+
+    <item
         android:id="@+id/action_colored_footers"
         android:checkable="true"
         android:title="@string/colored_footers" />

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -6,6 +6,12 @@
     <item name="action_album_sort_asc" type="id" />
     <item name="action_album_sort_desc" type="id" />
     <item name="action_album_sort_artist" type="id" />
+    <item name="action_album_sort_year" type="id" />
     <item name="action_artist_sort_asc" type="id" />
     <item name="action_artist_sort_desc" type="id" />
+    <item name="action_song_sort_asc" type="id" />
+    <item name="action_song_sort_desc" type="id" />
+    <item name="action_song_sort_artist" type="id" />
+    <item name="action_song_sort_album" type="id" />
+    <item name="action_song_sort_year" type="id" />
 </resources>

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -2,4 +2,10 @@
 <resources>
     <item name="action_new_playlist" type="id" />
     <item name="action_show_lyrics" type="id" />
+
+    <item name="action_album_sort_asc" type="id" />
+    <item name="action_album_sort_desc" type="id" />
+    <item name="action_album_sort_artist" type="id" />
+    <item name="action_artist_sort_asc" type="id" />
+    <item name="action_artist_sort_desc" type="id" />
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -299,4 +299,5 @@
     <string name="sort_z_a">Descending</string>
     <string name="sort_artist">Artist</string>
     <string name="sort_album">Album</string>
+    <string name="sort_year">Year</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -294,4 +294,9 @@
     <string name="library_categories">Library categories</string>
     <string name="pref_summary_library_categories">Configure visibility and order of library categories.</string>
     <string name="you_have_to_select_at_least_one_category">You have to select at least one category.</string>
+    <string name="action_sort">Sort order</string>
+    <string name="sort_a_z">Ascending</string>
+    <string name="sort_z_a">Descending</string>
+    <string name="sort_artist">Artist</string>
+    <string name="sort_album">Album</string>
 </resources>


### PR DESCRIPTION
Fixes #66 

The ability to sort library views is the only thing I've been missing in this app for years now, so I finally took a look at the source and fixed it myself. I'm not experienced with Android development specifically, so I apologize if I've done anything weird in this PR-- just let me know and I'll fix it.

I implemented menu options for the SortOrder options that made sense. Sorting albums by number of songs, for example, seemed useless. The fast-scroll `getSectionName` implementations have also been changed appropriately for each sorting method.