### PR TITLE
Use black navigation buttons on navbar if light colored for SDK >= Oreo

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -94,7 +94,6 @@ dependencies {
     implementation "com.android.support:percent:$supportLibVersion"
     implementation "com.android.support:preference-v7:$supportLibVersion"
     implementation "com.android.support:preference-v14:$supportLibVersion"
-    implementation 'com.github.kabouzeid:app-theme-helper:1.3.9'
     implementation 'com.github.kabouzeid:RecyclerView-FastScroll:1.0.16-kmod'
     implementation 'com.github.kabouzeid:SeekArc:1.2-kmod'
     implementation 'com.github.kabouzeid:AndroidSlidingUpPanel:3.3.0-kmod3'
@@ -118,4 +117,5 @@ dependencies {
     }
     implementation 'com.google.code.gson:gson:2.8.2'
     annotationProcessor 'com.jakewharton:butterknife-compiler:8.8.1'
+    compile project(":library-debug")
 }

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/activities/base/AbsThemeActivity.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/activities/base/AbsThemeActivity.java
@@ -15,6 +15,9 @@ import com.kabouzeid.gramophone.R;
 import com.kabouzeid.gramophone.util.PreferenceUtil;
 import com.kabouzeid.gramophone.util.Util;
 
+import static android.view.View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR;
+import static android.view.View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
+
 /**
  * @author Karim Abou Zeid (kabouzeid)
  */
@@ -71,9 +74,10 @@ public abstract class AbsThemeActivity extends ATHToolbarActivity {
         setTaskDescriptionColor(ThemeStore.primaryColor(this));
     }
 
-    public void setNavigationbarColor(int color) {
+    public void setNavigationbarColor(int color) { 
         if (ThemeStore.coloredNavigationBar(this)) {
             ATH.setNavigationbarColor(this, color);
+            setLightStatusbarAuto(color);
         } else {
             ATH.setNavigationbarColor(this, Color.BLACK);
         }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,3 @@
+include ':app', ':library-debug'
+
 include ':app'


### PR DESCRIPTION
This is dependent on the updates I made to the ATH class https://github.com/kabouzeid/app-theme-helper/pull/7