### PR TITLE
fix png files not loading

### DIFF
--- a/app/src/main/java/com/kabouzeid/gramophone/adapter/album/HorizontalAlbumAdapter.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/adapter/album/HorizontalAlbumAdapter.java
@@ -76,11 +76,7 @@ public class HorizontalAlbumAdapter extends AlbumAdapter {
 
     @Override
     protected String getAlbumText(Album album) {
-		int year = album.getYear();
-		if(year > 0) {
-			return String.valueOf(year);
-		}
-		return "-";
+        return String.valueOf(album.getYear());
     }
 
     @Override

--- a/app/src/main/java/com/kabouzeid/gramophone/glide/audiocover/AudioFileCoverFetcher.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/glide/audiocover/AudioFileCoverFetcher.java
@@ -45,7 +45,8 @@ public class AudioFileCoverFetcher implements DataFetcher<InputStream> {
         }
     }
 
-    private static final String[] FALLBACKS = {"cover.jpg", "album.jpg", "folder.jpg"};
+    private static final String[] FALLBACKS
+            = {"cover.jpg", "album.jpg", "folder.jpg", "cover.png", "album.png", "folder.png"};
 
     private InputStream fallback(String path) throws FileNotFoundException {
         File parent = new File(path).getParentFile();


### PR DESCRIPTION
This fixes some broken images on the manual scan with a couple additions to the album cover search filter. I also modified the horizontal album adapter so an unknown year value will match the album view details.