### PR TITLE
Bulk playlist export

### DIFF
--- a/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/LibraryFragment.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/LibraryFragment.java
@@ -1,9 +1,12 @@
 package com.kabouzeid.gramophone.ui.fragments.mainactivity.library;
 
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -19,6 +22,7 @@ import android.view.MenuItem;
 import android.view.SubMenu;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Toast;
 
 import com.afollestad.materialcab.MaterialCab;
 import com.kabouzeid.appthemehelper.ThemeStore;
@@ -41,6 +45,7 @@ import com.kabouzeid.gramophone.ui.fragments.mainactivity.library.pager.ArtistsF
 import com.kabouzeid.gramophone.ui.fragments.mainactivity.library.pager.PlaylistsFragment;
 import com.kabouzeid.gramophone.ui.fragments.mainactivity.library.pager.SongsFragment;
 import com.kabouzeid.gramophone.util.PhonographColorUtil;
+import com.kabouzeid.gramophone.util.PlaylistsUtil;
 import com.kabouzeid.gramophone.util.PreferenceUtil;
 import com.kabouzeid.gramophone.util.Util;
 
@@ -250,7 +255,29 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
                 CreatePlaylistDialog.create().show(getChildFragmentManager(), "CREATE_PLAYLIST");
                 return true;
             case R.id.action_export_playlists:
-                // TODO
+                @SuppressLint("ShowToast")
+                final Toast toast = Toast.makeText(getActivity(), R.string.saving_playlists, Toast.LENGTH_LONG);
+                new AsyncTask<Context, Void, String>() {
+                    @Override
+                    protected void onPreExecute() {
+                        super.onPreExecute();
+                        toast.show();
+                    }
+
+                    @Override
+                    protected String doInBackground(Context... params) {
+                        return PlaylistsUtil.saveAllPlaylists(params[0]);
+                    }
+
+                    @Override
+                    protected void onPostExecute(String string) {
+                        super.onPostExecute(string);
+                        if (toast != null) {
+                            toast.setText(string);
+                            toast.show();
+                        }
+                    }
+                }.execute(getActivity().getApplicationContext());
                 return true;
             case R.id.action_search:
                 startActivity(new Intent(getActivity(), SearchActivity.class));

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/LibraryFragment.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/LibraryFragment.java
@@ -188,6 +188,7 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
         inflater.inflate(R.menu.menu_main, menu);
         if (isPlaylistPage()) {
             menu.add(0, R.id.action_new_playlist, 0, R.string.new_playlist_title);
+            menu.add(0, R.id.action_export_playlists, 1, R.string.export_playlists);
         }
         Fragment currentFragment = getCurrentFragment();
         if (currentFragment instanceof AbsLibraryPagerRecyclerViewCustomGridSizeFragment && currentFragment.isAdded()) {
@@ -247,6 +248,9 @@ public class LibraryFragment extends AbsMainActivityFragment implements CabHolde
                 return true;
             case R.id.action_new_playlist:
                 CreatePlaylistDialog.create().show(getChildFragmentManager(), "CREATE_PLAYLIST");
+                return true;
+            case R.id.action_export_playlists:
+                // TODO
                 return true;
             case R.id.action_search:
                 startActivity(new Intent(getActivity(), SearchActivity.class));

--- a/app/src/main/java/com/kabouzeid/gramophone/util/PlaylistsUtil.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/util/PlaylistsUtil.java
@@ -14,6 +14,7 @@ import android.widget.Toast;
 
 import com.kabouzeid.gramophone.R;
 import com.kabouzeid.gramophone.helper.M3UWriter;
+import com.kabouzeid.gramophone.loader.PlaylistLoader;
 import com.kabouzeid.gramophone.model.Playlist;
 import com.kabouzeid.gramophone.model.PlaylistSong;
 import com.kabouzeid.gramophone.model.Song;
@@ -246,6 +247,25 @@ public class PlaylistsUtil {
 
     public static File savePlaylist(Context context, Playlist playlist) throws IOException {
         return M3UWriter.write(context, new File(Environment.getExternalStorageDirectory(), "Playlists"), playlist);
+    }
+
+    public static String saveAllPlaylists(Context context) {
+        int successes = 0, failures = 0;
+        File dir = new File(Environment.getExternalStorageDirectory(), "Playlists");
+
+        List<Playlist> playlists = PlaylistLoader.getAllPlaylists(context);
+        for (Playlist playlist : playlists) {
+            try {
+                savePlaylist(context, playlist);
+                successes++;
+            } catch (IOException ignored) {
+                failures++;
+            }
+        }
+
+        return failures == 0
+                ? String.format(context.getString(R.string.saved_x_playlists_to_x), successes, dir)
+                : String.format(context.getString(R.string.saved_x_playlists_to_x_failed_to_save_x), successes, dir, failures);
     }
 
     private static boolean doesPlaylistExist(@NonNull Context context, @NonNull final String selection, @NonNull final String[] values) {

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <item name="action_new_playlist" type="id" />
+    <item name="action_export_playlists" type="id" />
     <item name="action_show_lyrics" type="id" />
 
     <item name="action_album_sort_order_asc" type="id" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -234,6 +234,7 @@
     <string name="folders">Folders</string>
     <string name="saved_playlist_to">Saved playlist to %s.</string>
     <string name="failed_to_save_playlist">Failed to save playlist (%s).</string>
+    <string name="saving_playlists">Saving playlists…</string>
     <string name="saved_x_playlists_to_x">Saved %1$d playlists to %2$s.</string>
     <string name="saved_x_playlists_to_x_failed_to_save_x">Saved %1$d playlists to %2$s, failed to save %3$d.</string>
     <string name="not_listed_in_media_store"><![CDATA[<b>%s</b> is not listed in the media store.]]></string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -182,6 +182,7 @@
     <string name="sleep_timer_set">Sleep timer set for %d minutes from now.</string>
     <string name="action_new_playlist">New playlist…</string>
     <string name="new_playlist_title">New playlist</string>
+    <string name="export_playlists">Export playlists</string>
     <string name="grid_size_1">1</string>
     <string name="grid_size_2">2</string>
     <string name="grid_size_3">3</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -234,6 +234,8 @@
     <string name="folders">Folders</string>
     <string name="saved_playlist_to">Saved playlist to %s.</string>
     <string name="failed_to_save_playlist">Failed to save playlist (%s).</string>
+    <string name="saved_x_playlists_to_x">Saved %1$d playlists to %2$s.</string>
+    <string name="saved_x_playlists_to_x_failed_to_save_x">Saved %1$d playlists to %2$s, failed to save %3$d.</string>
     <string name="not_listed_in_media_store"><![CDATA[<b>%s</b> is not listed in the media store.]]></string>
     <string name="some_files_are_not_listed_in_the_media_store">Some files are not listed in the media store.</string>
     <string name="nothing_to_scan">Nothing to scan.</string>


### PR DESCRIPTION
It's great that Phonograph already lets users save individual playlists as M3U files, but when one is really invested in the whole playlist thing and ends up with 69 of them like me, going through them individually to manually back them up is a bit of a hassle.

This adds an item to the options menu of the library when the playlists tab is visible, which lets the user export all playlists at once. I thought about integrating this into the multiselection to give more fine grained control over which playlists are saved, but since it's not currently possible to select all items with once click, the user would still have to select 69 items by hand in my case. So I ended up just adding the option to export all playlists, which is a pretty minor change.