### PR TITLE
Support notches (non-standard sized status bar)

### DIFF
--- a/app/src/main/java/com/kabouzeid/gramophone/ui/activities/MainActivity.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/activities/MainActivity.java
@@ -84,11 +84,6 @@ public class MainActivity extends AbsSlidingMusicPanelActivity {
             navigationView.setFitsSystemWindows(false);
             //noinspection ConstantConditions
             findViewById(R.id.drawer_content_container).setFitsSystemWindows(false);
-        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            drawerLayout.setOnApplyWindowInsetsListener((view, windowInsets) -> {
-                navigationView.dispatchApplyWindowInsets(windowInsets);
-                return windowInsets.replaceSystemWindowInsets(0, 0, 0, 0);
-            });
         }
 
         setUpDrawerLayout();
@@ -102,6 +97,8 @@ public class MainActivity extends AbsSlidingMusicPanelActivity {
         if (!checkShowIntro()) {
             checkShowChangelog();
         }
+
+        setStatusbarColor(ThemeStore.primaryColorDark(this));
     }
 
     private void setMusicChooser(int key) {

--- a/app/src/main/res/layout-land/fragment_card_player.xml
+++ b/app/src/main/res/layout-land/fragment_card_player.xml
@@ -13,8 +13,6 @@
         android:orientation="vertical"
         tools:ignore="UselessParent">
 
-        <include layout="@layout/status_bar" />
-
         <android.support.v7.widget.Toolbar
             android:id="@+id/player_toolbar"
             style="@style/Toolbar"

--- a/app/src/main/res/layout-land/fragment_flat_player.xml
+++ b/app/src/main/res/layout-land/fragment_flat_player.xml
@@ -1,27 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
-
-    <FrameLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:elevation="@dimen/toolbar_elevation"
-        tools:ignore="UnusedAttribute">
-
-        <View
-            android:id="@+id/player_status_bar"
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/status_bar_padding" />
-
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/status_bar_padding"
-            android:background="@color/twenty_percent_black_overlay" />
-
-    </FrameLayout>
 
     <android.support.v7.widget.Toolbar
         android:id="@+id/player_toolbar"

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -4,9 +4,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    tools:context=".ui.activities.AboutActivity">
-
-    <include layout="@layout/status_bar" />
+    tools:context=".ui.activities.AboutActivity"
+    android:fitsSystemWindows="true">
 
     <android.support.v7.widget.Toolbar
         android:id="@+id/toolbar"

--- a/app/src/main/res/layout/activity_album_detail.xml
+++ b/app/src/main/res/layout/activity_album_detail.xml
@@ -4,9 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
-
-    <include layout="@layout/status_bar" />
+    android:orientation="vertical"
+    android:fitsSystemWindows="true">
 
     <FrameLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_artist_detail.xml
+++ b/app/src/main/res/layout/activity_artist_detail.xml
@@ -4,9 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
-
-    <include layout="@layout/status_bar" />
+    android:orientation="vertical"
+    android:fitsSystemWindows="true">
 
     <FrameLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_genre_detail.xml
+++ b/app/src/main/res/layout/activity_genre_detail.xml
@@ -4,14 +4,13 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:transitionGroup="true"
-    tools:ignore="UnusedAttribute">
+    tools:ignore="UnusedAttribute"
+    android:fitsSystemWindows="true">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical">
-
-        <include layout="@layout/status_bar" />
 
         <FrameLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_main_drawer_layout.xml
+++ b/app/src/main/res/layout/activity_main_drawer_layout.xml
@@ -4,9 +4,9 @@
     android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true">
+    android:fitsSystemWindows="false">
 
-    <android.support.design.internal.ScrimInsetsFrameLayout
+    <FrameLayout
         android:id="@+id/drawer_content_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/app/src/main/res/layout/activity_playlist_detail.xml
+++ b/app/src/main/res/layout/activity_playlist_detail.xml
@@ -4,14 +4,13 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:transitionGroup="true"
-    tools:ignore="UnusedAttribute">
+    tools:ignore="UnusedAttribute"
+    android:fitsSystemWindows="true">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical">
-
-        <include layout="@layout/status_bar" />
 
         <FrameLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_preferences.xml
+++ b/app/src/main/res/layout/activity_preferences.xml
@@ -2,9 +2,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
-
-    <include layout="@layout/status_bar" />
+    android:orientation="vertical"
+    android:fitsSystemWindows="true">
 
     <android.support.v7.widget.Toolbar
         android:id="@+id/toolbar"

--- a/app/src/main/res/layout/activity_purchase.xml
+++ b/app/src/main/res/layout/activity_purchase.xml
@@ -4,15 +4,13 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    tools:context=".ui.activities.PurchaseActivity">
-
-    <include layout="@layout/status_bar" />
+    tools:context=".ui.activities.PurchaseActivity"
+    android:fitsSystemWindows="true">
 
     <android.support.design.widget.AppBarLayout
         android:id="@+id/app_bar"
         android:layout_width="match_parent"
         android:layout_height="128dp"
-        android:layout_below="@+id/status_bar"
         android:background="@color/md_green_500"
         android:elevation="4dp">
 

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -2,9 +2,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
-
-    <include layout="@layout/status_bar" />
+    android:orientation="vertical"
+    android:fitsSystemWindows="true">
 
     <android.support.v7.widget.Toolbar
         android:id="@+id/toolbar"

--- a/app/src/main/res/layout/fragment_card_player.xml
+++ b/app/src/main/res/layout/fragment_card_player.xml
@@ -68,7 +68,6 @@
                 <android.support.v7.widget.Toolbar
                     android:id="@+id/player_toolbar"
                     style="@style/Toolbar"
-                    android:layout_marginTop="@dimen/status_bar_padding"
                     android:background="@android:color/transparent" />
 
             </FrameLayout>

--- a/app/src/main/res/layout/fragment_flat_player.xml
+++ b/app/src/main/res/layout/fragment_flat_player.xml
@@ -4,22 +4,6 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <FrameLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content">
-
-        <View
-            android:id="@+id/player_status_bar"
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/status_bar_padding" />
-
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/status_bar_padding"
-            android:background="@color/twenty_percent_black_overlay" />
-
-    </FrameLayout>
-
     <com.sothree.slidinguppanel.SlidingUpPanelLayout
         xmlns:sothree="http://schemas.android.com/apk/res-auto"
         android:id="@+id/player_sliding_layout"

--- a/app/src/main/res/layout/fragment_folder.xml
+++ b/app/src/main/res/layout/fragment_folder.xml
@@ -1,89 +1,73 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+
+<android.support.design.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/coordinator_layout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    tools:context=".ui.fragments.mainactivity.folders.FoldersFragment">
+    android:layout_height="match_parent">
 
-    <FrameLayout
+    <android.support.design.widget.AppBarLayout
+        android:id="@+id/appbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:elevation="0dp"
         tools:ignore="UnusedAttribute">
 
-        <include layout="@layout/status_bar" />
-
-    </FrameLayout>
-
-    <android.support.design.widget.CoordinatorLayout
-        android:id="@+id/coordinator_layout"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
-
-        <android.support.design.widget.AppBarLayout
-            android:id="@+id/appbar"
+        <FrameLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            tools:ignore="UnusedAttribute">
+            app:layout_scrollFlags="scroll|enterAlways">
 
-            <FrameLayout
+            <android.support.v7.widget.Toolbar
+                android:id="@+id/toolbar"
+                style="@style/Toolbar"
+                android:elevation="0dp"
+                tools:ignore="UnusedAttribute">
+
+            </android.support.v7.widget.Toolbar>
+
+            <ViewStub
+                android:id="@+id/cab_stub"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:layout_scrollFlags="scroll|enterAlways">
-
-                <android.support.v7.widget.Toolbar
-                    android:id="@+id/toolbar"
-                    style="@style/Toolbar"
-                    android:elevation="0dp"
-                    tools:ignore="UnusedAttribute">
-
-                </android.support.v7.widget.Toolbar>
-
-                <ViewStub
-                    android:id="@+id/cab_stub"
-                    android:layout_width="match_parent"
-                    android:layout_height="?attr/actionBarSize" />
-
-            </FrameLayout>
-
-            <com.kabouzeid.gramophone.views.BreadCrumbLayout
-                android:id="@+id/bread_crumbs"
-                android:layout_width="match_parent"
-                android:layout_height="@dimen/tab_height"
-                android:paddingEnd="8dp"
-                android:paddingLeft="60dp"
-                android:paddingRight="8dp"
-                android:paddingStart="60dp" />
-
-        </android.support.design.widget.AppBarLayout>
-
-        <FrameLayout
-            android:id="@+id/container"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:layout_behavior="@string/appbar_scrolling_view_behavior">
-
-            <com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView
-                android:id="@+id/recycler_view"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:clipToPadding="false"
-                android:scrollbars="none" />
-
-            <TextView
-                android:id="@android:id/empty"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:fontFamily="sans-serif-light"
-                android:text="@string/empty"
-                android:textColor="?android:textColorSecondary"
-                android:textSize="@dimen/empty_text_size" />
+                android:layout_height="?attr/actionBarSize"/>
 
         </FrameLayout>
 
-    </android.support.design.widget.CoordinatorLayout>
+        <com.kabouzeid.gramophone.views.BreadCrumbLayout
+            android:id="@+id/bread_crumbs"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/tab_height"
+            android:paddingEnd="8dp"
+            android:paddingLeft="60dp"
+            android:paddingRight="8dp"
+            android:paddingStart="60dp"/>
 
-</LinearLayout>
+    </android.support.design.widget.AppBarLayout>
+
+    <FrameLayout
+        android:id="@+id/container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView
+            android:id="@+id/recycler_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:clipToPadding="false"
+            android:scrollbars="none"/>
+
+        <TextView
+            android:id="@android:id/empty"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:fontFamily="sans-serif-light"
+            android:text="@string/empty"
+            android:textColor="?android:textColorSecondary"
+            android:textSize="@dimen/empty_text_size"/>
+
+    </FrameLayout>
+
+</android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_library.xml
+++ b/app/src/main/res/layout/fragment_library.xml
@@ -1,67 +1,51 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.design.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    tools:context=".ui.fragments.mainactivity.library.LibraryFragment">
+    android:layout_height="match_parent">
 
-    <FrameLayout
+    <android.support.design.widget.AppBarLayout
+        android:id="@+id/appbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:elevation="0dp"
         tools:ignore="UnusedAttribute">
 
-        <include layout="@layout/status_bar" />
-
-    </FrameLayout>
-
-    <android.support.design.widget.CoordinatorLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
-
-        <android.support.design.widget.AppBarLayout
-            android:id="@+id/appbar"
+        <FrameLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            tools:ignore="UnusedAttribute">
+            app:layout_scrollFlags="scroll|enterAlways">
 
-            <FrameLayout
+            <android.support.v7.widget.Toolbar
+                android:id="@+id/toolbar"
+                style="@style/Toolbar"
+                android:elevation="0dp"
+                tools:ignore="UnusedAttribute">
+
+            </android.support.v7.widget.Toolbar>
+
+            <ViewStub
+                android:id="@+id/cab_stub"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:layout_scrollFlags="scroll|enterAlways">
+                android:layout_height="?attr/actionBarSize"/>
 
-                <android.support.v7.widget.Toolbar
-                    android:id="@+id/toolbar"
-                    style="@style/Toolbar"
-                    android:elevation="0dp"
-                    tools:ignore="UnusedAttribute">
+        </FrameLayout>
 
-                </android.support.v7.widget.Toolbar>
-
-                <ViewStub
-                    android:id="@+id/cab_stub"
-                    android:layout_width="match_parent"
-                    android:layout_height="?attr/actionBarSize" />
-
-            </FrameLayout>
-
-            <android.support.design.widget.TabLayout
-                android:id="@+id/tabs"
-                android:layout_width="match_parent"
-                android:layout_height="@dimen/tab_height"
-                app:tabContentStart="72dp"
-                app:tabMode="scrollable" />
-
-        </android.support.design.widget.AppBarLayout>
-
-        <android.support.v4.view.ViewPager
-            android:id="@+id/pager"
+        <android.support.design.widget.TabLayout
+            android:id="@+id/tabs"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+            android:layout_height="@dimen/tab_height"
+            app:tabContentStart="72dp"
+            app:tabMode="scrollable"/>
 
-    </android.support.design.widget.CoordinatorLayout>
+    </android.support.design.widget.AppBarLayout>
 
-</LinearLayout>
+    <android.support.v4.view.ViewPager
+        android:id="@+id/pager"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"/>
+
+</android.support.design.widget.CoordinatorLayout>
+

--- a/app/src/main/res/layout/navigation_drawer_header.xml
+++ b/app/src/main/res/layout/navigation_drawer_header.xml
@@ -1,4 +1,4 @@
-<android.support.percent.PercentFrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<com.kabouzeid.gramophone.views.WidthFitSquareLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/header"
@@ -13,8 +13,8 @@
         android:scaleType="centerCrop"
         android:src="@drawable/default_album_art"
         android:transitionName="@string/transition_album_art"
-        app:layout_aspectRatio="178%"
-        app:layout_widthPercent="100%"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
         tools:ignore="ContentDescription,UnusedAttribute" />
 
     <View
@@ -57,4 +57,4 @@
 
     </LinearLayout>
 
-</android.support.percent.PercentFrameLayout>
+</com.kabouzeid.gramophone.views.WidthFitSquareLayout>

--- a/app/src/main/res/layout/shadow_statusbar_toolbar.xml
+++ b/app/src/main/res/layout/shadow_statusbar_toolbar.xml
@@ -4,27 +4,16 @@
     android:layout_height="@dimen/toolbar_scrim_height"
     android:orientation="vertical">
 
-    <LinearLayout
-        android:id="@+id/dummy_statusbar_actionbar"
+    <View
+        android:id="@+id/dummy_toolbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical">
-
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/status_bar_padding" />
-
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="?actionBarSize" />
-
-    </LinearLayout>
+        android:layout_height="?actionBarSize" />
 
     <View
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_alignBottom="@id/dummy_statusbar_actionbar"
-        android:layout_alignTop="@id/dummy_statusbar_actionbar"
+        android:layout_alignBottom="@id/dummy_toolbar"
+        android:layout_alignTop="@id/dummy_toolbar"
         android:background="@drawable/toolbar_gradient" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/status_bar.xml
+++ b/app/src/main/res/layout/status_bar.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--suppress AndroidDomInspection -->
 <View xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/status_bar"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/status_bar_padding"
+    android:layout_height="@*android:dimen/status_bar_height"
     android:background="@android:color/transparent"
     android:elevation="@dimen/toolbar_elevation"
     tools:ignore="UnusedAttribute" />


### PR DESCRIPTION
Phonograph draws the status bar artificially (fixed-sized, darker colored background on top).
The default status bar size is set (correctly!) to 25dp on pre-M devices and 24dp on M+ devices.
Since some devices nowadays have notches the status bar size on those phones differs from the default.

On OnePlus 6 the status bar matches the size of the notch, causing the old implementation to draw a smaller "status bar" leading to weird UI and inconsistency with other apps. On OP6 the status bar size is 30+dp. Since the status bar size is a system defined property it should work on all devices regardless of the presence of a notch.

This fix changes the height of the status bar from fixed size to the system defined property.
This fix is not perfect as it is accessing a private property but ATM there is no official API that can be used instead. Proper test would be to run the app on different OS versions as the property name is the same on all devices on the same OS version. Additionally, it would be possible to add minHeight to 24 or 25dp as a fallback option as the status bar can only be bigger than the default because of the notch.

Tested: OnePlus 6, Oreo 8.1