### PR TITLE
Fixes statusbar for non-standard statusbar sizes

### DIFF
--- a/app/src/main/res/values-v23/dimens.xml
+++ b/app/src/main/res/values-v23/dimens.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <dimen name="status_bar_padding">24dp</dimen>
+    <dimen name="status_bar_padding">@*android:dimen/status_bar_height</dimen>
 </resources>


### PR DESCRIPTION
Only issue with this fix is that this will screw up the statusbar for Android P developer preview devices. The fix for that is quite simple, however, it requires that the app's targetSdkVersion be set to P. This in itself causes several issues for now, specifically being that **Google currently does not allow apps targeting P to be installed on non-P devices**. 

This will obviously be fixed once Google finalises APIs in dev preview 3 or 4, however.
I have a custom branch for Android P for now, and will open another pull request once P releases.