### PR TITLE
Added preference to turn off shuffle mode when selecting new list of songs

### DIFF
--- a/app/src/main/java/com/kabouzeid/gramophone/helper/MusicPlayerRemote.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/helper/MusicPlayerRemote.java
@@ -24,6 +24,7 @@ import com.kabouzeid.gramophone.R;
 import com.kabouzeid.gramophone.loader.SongLoader;
 import com.kabouzeid.gramophone.model.Song;
 import com.kabouzeid.gramophone.service.MusicService;
+import com.kabouzeid.gramophone.util.PreferenceUtil;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -176,6 +177,8 @@ public class MusicPlayerRemote {
     public static void openQueue(final ArrayList<Song> queue, final int startPosition, final boolean startPlaying) {
         if (!tryToHandleOpenPlayingQueue(queue, startPosition, startPlaying) && musicService != null) {
             musicService.openQueue(queue, startPosition, startPlaying);
+            if (!PreferenceUtil.getInstance(musicService).rememberShuffle())
+                setShuffleMode(MusicService.SHUFFLE_MODE_NONE);
         }
     }
 

--- a/app/src/main/java/com/kabouzeid/gramophone/helper/MusicPlayerRemote.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/helper/MusicPlayerRemote.java
@@ -177,8 +177,9 @@ public class MusicPlayerRemote {
     public static void openQueue(final ArrayList<Song> queue, final int startPosition, final boolean startPlaying) {
         if (!tryToHandleOpenPlayingQueue(queue, startPosition, startPlaying) && musicService != null) {
             musicService.openQueue(queue, startPosition, startPlaying);
-            if (!PreferenceUtil.getInstance(musicService).rememberShuffle())
+            if (!PreferenceUtil.getInstance(musicService).rememberShuffle()){
                 setShuffleMode(MusicService.SHUFFLE_MODE_NONE);
+            }
         }
     }
 

--- a/app/src/main/java/com/kabouzeid/gramophone/util/PreferenceUtil.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/util/PreferenceUtil.java
@@ -82,6 +82,8 @@ public final class PreferenceUtil {
 
     public static final String LIBRARY_CATEGORIES = "library_categories";
 
+    private static final String REMEMBER_SHUFFLE = "remember_shuffle";
+
     private static PreferenceUtil sInstance;
 
     private final SharedPreferences mPreferences;
@@ -430,6 +432,10 @@ public final class PreferenceUtil {
 
     public final boolean introShown() {
         return mPreferences.getBoolean(INTRO_SHOWN, false);
+    }
+
+    public final boolean rememberShuffle() {
+        return mPreferences.getBoolean(REMEMBER_SHUFFLE, true);
     }
 
     public final String autoDownloadImagesPolicy() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,7 +131,7 @@
     <string name="pref_title_last_added_interval">Last added playlist interval</string>
     <string name="pref_title_synchronized_lyrics_show">Show synchronized lyrics</string>
     <string name="pref_title_remember_last_tab">Remember last tab</string>
-    <string name="pref_title_remember_shuffle">Remember Shuffle</string>
+    <string name="pref_title_remember_shuffle">Remember shuffle</string>
     <string name="no_equalizer">No equalizer found.</string>
     <string name="no_audio_ID">"Play a song first, then try again."</string>
     <string name="delete_action">Delete</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,6 +131,7 @@
     <string name="pref_title_last_added_interval">Last added playlist interval</string>
     <string name="pref_title_synchronized_lyrics_show">Show synchronized lyrics</string>
     <string name="pref_title_remember_last_tab">Remember last tab</string>
+    <string name="pref_title_remember_shuffle">Remember Shuffle</string>
     <string name="no_equalizer">No equalizer found.</string>
     <string name="no_audio_ID">"Play a song first, then try again."</string>
     <string name="delete_action">Delete</string>
@@ -165,6 +166,7 @@
     <string name="pref_summary_audio_ducking">Notifications, navigation etc.</string>
     <string name="pref_summary_synchronized_lyrics_show">Currently only synchronized lyrics in LRC format are supported. Either embedded or as a separate file.</string>
     <string name="pref_summary_remember_last_tab">Go to the last opened tab on launch</string>
+    <string name="pref_summary_remember_shuffle">Shuffle mode will stay on when selecting a new list of songs</string>
     <string name="could_not_download_album_cover">"Couldn\u2019t download a matching album cover."</string>
     <string name="search_hint">Search your library…</string>
     <string name="favorites">Favorites</string>

--- a/app/src/main/res/xml/pref_audio.xml
+++ b/app/src/main/res/xml/pref_audio.xml
@@ -19,8 +19,7 @@
             android:defaultValue="true"
             android:key="remember_shuffle"
             android:summary="@string/pref_summary_remember_shuffle"
-            android:title="@string/pref_title_remember_shuffle"/>
-
+            android:title="@string/pref_title_remember_shuffle" />
 
         <com.kabouzeid.appthemehelper.common.prefs.supportv7.ATEPreference
             android:key="equalizer"

--- a/app/src/main/res/xml/pref_audio.xml
+++ b/app/src/main/res/xml/pref_audio.xml
@@ -15,6 +15,13 @@
             android:summary="@string/pref_summary_gapless_playback"
             android:title="@string/pref_title_gapless_playback" />
 
+        <com.kabouzeid.appthemehelper.common.prefs.supportv7.ATESwitchPreference
+            android:defaultValue="true"
+            android:key="remember_shuffle"
+            android:summary="@string/pref_summary_remember_shuffle"
+            android:title="@string/pref_title_remember_shuffle"/>
+
+
         <com.kabouzeid.appthemehelper.common.prefs.supportv7.ATEPreference
             android:key="equalizer"
             android:title="@string/equalizer" />


### PR DESCRIPTION
An option to turn sticky shuffle on or off. It's enabled by default so it keeps the current functionality the same. I noticed every other player has it so hopefully you don't have any issues with it being in the app.