### PR TITLE
Fix loading of large embedded album art

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -137,6 +137,5 @@ dependencies {
         transitive = true
     }
     implementation 'com.google.code.gson:gson:2.8.2'
-    implementation 'com.mpatric:mp3agic:0.9.1'
     annotationProcessor 'com.jakewharton:butterknife-compiler:8.8.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -137,5 +137,6 @@ dependencies {
         transitive = true
     }
     implementation 'com.google.code.gson:gson:2.8.2'
+    implementation 'com.mpatric:mp3agic:0.9.1'
     annotationProcessor 'com.jakewharton:butterknife-compiler:8.8.1'
 }

--- a/app/src/main/java/com/kabouzeid/gramophone/glide/audiocover/AudioFileCoverFetcher.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/glide/audiocover/AudioFileCoverFetcher.java
@@ -4,6 +4,10 @@ import android.media.MediaMetadataRetriever;
 
 import com.bumptech.glide.Priority;
 import com.bumptech.glide.load.data.DataFetcher;
+import com.mpatric.mp3agic.ID3v2;
+import com.mpatric.mp3agic.InvalidDataException;
+import com.mpatric.mp3agic.Mp3File;
+import com.mpatric.mp3agic.UnsupportedTagException;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -48,6 +52,23 @@ public class AudioFileCoverFetcher implements DataFetcher<InputStream> {
     private static final String[] FALLBACKS = {"cover.jpg", "album.jpg", "folder.jpg", "cover.png", "album.png", "folder.png"};
 
     private InputStream fallback(String path) throws FileNotFoundException {
+        // Method 1: use embedded high resolution album art if there is any
+        try {
+            Mp3File mp3File = new Mp3File(path);
+            if (mp3File.hasId3v2Tag()) {
+                ID3v2 id3v2Tag = mp3File.getId3v2Tag();
+                byte[] imageData = id3v2Tag.getAlbumImage();
+                if (imageData != null) {
+                    return new ByteArrayInputStream(imageData);
+                }
+            }
+        // If there are any exceptions, we ignore them and continue to the other fallback method
+        } catch (IOException ignored) {
+        } catch (InvalidDataException ignored) {
+        } catch (UnsupportedTagException ignored) {
+        }
+
+        // Method 2: look for album art in external files
         File parent = new File(path).getParentFile();
         for (String fallback : FALLBACKS) {
             File cover = new File(parent, fallback);


### PR DESCRIPTION
I noticed that embedded album art exceeding some size is not displayed. While looking into it, I noticed the following in the log.
```
? E/ID3: skipping huge ID3 metadata of size 3337734
com.kabouzeid.gramophone.debug E/MediaMetadataRetrieverJNI: getEmbeddedPicture: Call to getEmbeddedPicture failed because the ID3 tag is too big
```
A quick search revealed that the code responsible for reading ID3 tags in Android's Stagefright component skips tags larger than 3 MiB. You can see that on line 31 in the [source file](http://www.androidcodesearch.com/source/frameworks/av/media/libstagefright/id3/ID3.cpp).
The result is that the MediaStore won't deliver the album art. But the problem persists even when _Ignore Media Store covers_ is enabled, because the platform's MediaMetadataReceiver, which is used to get the image directly from the file, relies on Stagefright as well.

My solution is to use [mp3agic](https://github.com/mpatric/mp3agic) to get the image instead, if the previous attempt with `getEmbeddedPicture()` didn't work. Of course this only makes a difference when ignoring the MediaStore cover and loading it directly from the file, because the MediaStore still doesn't have the image.

I realize that adding a new dependency just to solve this edge case is not great, so I completely understand if you have some reservations and decide not to merge.