### PR TITLE
Add option to cancel notification on pause

### DIFF
--- a/app/src/main/java/com/kabouzeid/gramophone/service/notification/PlayingNotificationImpl.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/service/notification/PlayingNotificationImpl.java
@@ -43,6 +43,10 @@ public class PlayingNotificationImpl extends PlayingNotification {
 
         final boolean isPlaying = service.isPlaying();
 
+        if (!isPlaying && PreferenceUtil.getInstance(service).disappearingNotification()) {
+            stop();
+        }
+
         final RemoteViews notificationLayout = new RemoteViews(service.getPackageName(), R.layout.notification);
         final RemoteViews notificationLayoutBig = new RemoteViews(service.getPackageName(), R.layout.notification_big);
 

--- a/app/src/main/java/com/kabouzeid/gramophone/service/notification/PlayingNotificationImpl24.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/service/notification/PlayingNotificationImpl24.java
@@ -42,6 +42,10 @@ public class PlayingNotificationImpl24 extends PlayingNotification {
         final String text = TextUtils.isEmpty(albumName)
                 ? artistName : artistName + " - " + albumName;
 
+        if (!isPlaying && PreferenceUtil.getInstance(service).disappearingNotification()) {
+            stop();
+        }
+
         final int playButtonResId = isPlaying
                 ? R.drawable.ic_pause_white_24dp : R.drawable.ic_play_arrow_white_24dp;
 

--- a/app/src/main/java/com/kabouzeid/gramophone/util/PreferenceUtil.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/util/PreferenceUtil.java
@@ -53,6 +53,7 @@ public final class PreferenceUtil {
 
     public static final String COLORED_NOTIFICATION = "colored_notification";
     public static final String CLASSIC_NOTIFICATION = "classic_notification";
+    public static final String DISAPPEARING_NOTIFICATION = "disappearing_notification";
 
     public static final String COLORED_APP_SHORTCUTS = "colored_app_shortcuts";
 
@@ -176,6 +177,10 @@ public final class PreferenceUtil {
 
     public final boolean classicNotification() {
         return mPreferences.getBoolean(CLASSIC_NOTIFICATION, false);
+    }
+
+    public final boolean disappearingNotification() {
+        return mPreferences.getBoolean(DISAPPEARING_NOTIFICATION, false);
     }
 
     public void setColoredNotification(final boolean value) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -125,6 +125,7 @@
     <string name="pref_title_blurred_album_art">Blur album cover</string>
     <string name="pref_title_colored_notification">Colored notification</string>
     <string name="pref_title_classic_notification">Classic notification design</string>
+    <string name="pref_title_disappearing_notification">Disappearing notification</string>
     <string name="pref_title_ignore_media_store_artwork">Ignore Media Store covers</string>
     <string name="pref_title_gapless_playback">Gapless playback</string>
     <string name="pref_title_audio_ducking">Reduce volume on focus loss</string>
@@ -159,6 +160,7 @@
     <string name="pref_summary_blurred_album_art">Blurs the album cover on the lockscreen. Can cause problems with third party apps and widgets.</string>
     <string name="pref_summary_classic_notification">Use the classic notification design.</string>
     <string name="pref_summary_colored_notification">"Colors the notification in the album cover\u2019s vibrant color."</string>
+    <string name="pref_summary_disappearing_notification">Dismisses the notification when playback is paused.</string>
     <string name="pref_summary_gapless_playback">"Can cause playback issues on some devices."</string>
     <string name="pref_summary_ignore_media_store_artwork">Can increase the album cover quality but causes slower image loading times. Only enable this if you have problems with low resolution artworks.</string>
     <string name="pref_summary_colored_navigation_bar">Colors the navigation bar in the primary color.</string>

--- a/app/src/main/res/xml/pref_notification.xml
+++ b/app/src/main/res/xml/pref_notification.xml
@@ -14,6 +14,12 @@
             android:summary="@string/pref_summary_colored_notification"
             android:title="@string/pref_title_colored_notification" />
 
+        <com.kabouzeid.appthemehelper.common.prefs.supportv7.ATESwitchPreference
+            android:defaultValue="false"
+            android:key="disappearing_notification"
+            android:summary="@string/pref_summary_disappearing_notification"
+            android:title="@string/pref_title_disappearing_notification" />
+
     </com.kabouzeid.appthemehelper.common.prefs.supportv7.ATEPreferenceCategory>
 
 </android.support.v7.preference.PreferenceScreen>


### PR DESCRIPTION
The notification sticks around when playback is paused, which is great for most users who want to quickly resume listening. But there's also the other use case for people who tend to listen without interruption and press pause when they are done (substituting it for a stop button basically). For users who need this in most situations, it would be useful if the notification wouldn't have to be manually dismissed, instead disappearing by itself.

Belonging to the latter group, I added an option to get this behavior. It's off by default, so doesn't change any behavior without user intervention. It's a pretty nitpicky thing and I honestly don't know how many people would find this useful, but it's there if you want it.

<img src="https://user-images.githubusercontent.com/5547518/41762945-ca6a54d8-75fc-11e8-82cc-36cb7a57a796.png" alt="Screenshot of preferences" height="720">
