### PR TITLE
Mark names as not translatable

### DIFF
--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -7,8 +7,8 @@
     <string name="maarten_corpel" translatable="false">Maarten Corpel</string>
     <string name="michael_cook_cookicons" translatable="false">Michael Cook (Cookicons)</string>
     <string name="aleksandar_tesic" translatable="false">Aleksandar Tešić</string>
-    <string name="eugene_cheung">Eugene Cheung</string>
-    <string name="adrian">Adrian</string>
+    <string name="eugene_cheung" translatable="false">Eugene Cheung</string>
+    <string name="adrian" translatable="false">Adrian</string>
 
     <string name="aachen_germany" translatable="false">Aachen, Germany</string>
 


### PR DESCRIPTION
Since they're in `donottranslate.xml`, probably they should also be `translatable="false"` :)

"Card" and "Flat" (presumably for the Now Playing screen layout types) are also in `donottranslate.xml` but are not marked as `translatable="false"` – should they be? I can add them to this PR if so.