### PR TITLE
Allow non-persisted sorting of Artist Albums in ArtistDetailActivity --- WORK IN PROGRESS

### DIFF
--- a/app/src/main/java/com/kabouzeid/gramophone/ui/activities/ArtistDetailActivity.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/activities/ArtistDetailActivity.java
@@ -54,6 +54,7 @@ import com.kabouzeid.gramophone.util.PhonographColorUtil;
 import com.kabouzeid.gramophone.util.PreferenceUtil;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Locale;
 
 import butterknife.BindView;
@@ -109,6 +110,11 @@ public class ArtistDetailActivity extends AbsSlidingMusicPanelActivity implement
     private MaterialDialog biographyDialog;
     private HorizontalAlbumAdapter albumAdapter;
     private ArtistSongAdapter songAdapter;
+
+    private int albumSortOrder;
+    private static final int SORT_AZ_ASC = 0;
+    private static final int SORT_AZ_DESC = 1;
+    private static final int SORT_YEAR_ASC = 2;
 
     private LastFMRestClient lastFMRestClient;
 
@@ -376,6 +382,21 @@ public class ArtistDetailActivity extends AbsSlidingMusicPanelActivity implement
                 CustomArtistImageUtil.getInstance(ArtistDetailActivity.this).resetCustomArtistImage(artist);
                 forceDownload = true;
                 return true;
+            case R.id.action_artist_album_sort_order_asc:
+                item.setChecked(!item.isChecked());
+                albumSortOrder = SORT_AZ_ASC;
+                reload();
+                return true;
+            case R.id.action_artist_album_sort_order_desc:
+                item.setChecked(!item.isChecked());
+                albumSortOrder = SORT_AZ_DESC;
+                reload();
+                return true;
+            case R.id.action_artist_album_sort_order_year:
+                item.setChecked(!item.isChecked());
+                albumSortOrder = SORT_YEAR_ASC;
+                reload();
+                return true;
             case R.id.action_colored_footers:
                 item.setChecked(!item.isChecked());
                 setUsePalette(item.isChecked());
@@ -444,6 +465,20 @@ public class ArtistDetailActivity extends AbsSlidingMusicPanelActivity implement
         songCountTextView.setText(MusicUtil.getSongCountString(this, artist.getSongCount()));
         albumCountTextView.setText(MusicUtil.getAlbumCountString(this, artist.getAlbumCount()));
         durationTextView.setText(MusicUtil.getReadableDurationString(MusicUtil.getTotalDuration(this, artist.getSongs())));
+
+        switch(albumSortOrder) {
+            case SORT_AZ_ASC:
+                Collections.sort(artist.albums, (o1, o2) -> o1.getTitle().compareTo(o2.getTitle()));
+                break;
+            case SORT_AZ_DESC:
+                Collections.sort(artist.albums, (o1, o2) -> o2.getTitle().compareTo(o1.getTitle()));
+                break;
+            case SORT_YEAR_ASC:
+                Collections.sort(artist.albums, (o1, o2) -> String.valueOf(o1.getYear()).compareTo(String.valueOf(o2.getYear())));
+                break;
+            default:
+                break;
+        }
 
         songAdapter.swapDataSet(artist.getSongs());
         albumAdapter.swapDataSet(artist.albums);

--- a/app/src/main/java/com/kabouzeid/gramophone/util/PreferenceUtil.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/util/PreferenceUtil.java
@@ -32,6 +32,7 @@ public final class PreferenceUtil {
     public static final String ARTIST_SORT_ORDER = "artist_sort_order";
     public static final String ARTIST_SONG_SORT_ORDER = "artist_song_sort_order";
     public static final String ARTIST_ALBUM_SORT_ORDER = "artist_album_sort_order";
+    public static final String ARTIST_DETAIL_ALBUM_SORT_ORDER = "artist_detail_album_sort_order";
     public static final String ALBUM_SORT_ORDER = "album_sort_order";
     public static final String ALBUM_SONG_SORT_ORDER = "album_song_sort_order";
     public static final String SONG_SORT_ORDER = "song_sort_order";
@@ -263,6 +264,14 @@ public final class PreferenceUtil {
     public void setAlbumSortOrder(final String sortOrder) {
         final SharedPreferences.Editor editor = mPreferences.edit();
         editor.putString(ALBUM_SORT_ORDER, sortOrder);
+        editor.commit();
+    }
+
+    public final String getArtistDetailAlbumSortOrder() { return mPreferences.getString(ARTIST_DETAIL_ALBUM_SORT_ORDER, SortOrder.ArtistAlbumSortOrder.ALBUM_YEAR_ASC); }
+
+    public void setArtistDetailAlbumSortOrder(final String sortOrder) {
+        final SharedPreferences.Editor editor = mPreferences.edit();
+        editor.putString(ARTIST_DETAIL_ALBUM_SORT_ORDER, sortOrder);
         editor.commit();
     }
 

--- a/app/src/main/res/menu/menu_artist_detail.xml
+++ b/app/src/main/res/menu/menu_artist_detail.xml
@@ -40,6 +40,23 @@
         app:showAsAction="never" />
 
     <item
+        android:id="@+id/action_sort_order"
+        android:title="@string/action_sort_order"
+        app:showAsAction="never">
+        <menu>
+            <item
+                android:id="@+id/action_artist_album_sort_order_asc"
+                android:title="@string/sort_order_a_z" />
+            <item
+                android:id="@+id/action_artist_album_sort_order_desc"
+                android:title="@string/sort_order_z_a" />
+            <item
+                android:id="@id/action_artist_album_sort_order_year"
+                android:title="@string/sort_order_year" />
+        </menu>
+    </item>
+
+    <item
         android:id="@+id/action_colored_footers"
         android:checkable="true"
         android:title="@string/colored_footers"

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -7,6 +7,9 @@
     <item name="action_album_sort_order_desc" type="id" />
     <item name="action_album_sort_order_artist" type="id" />
     <item name="action_album_sort_order_year" type="id" />
+    <item name="action_artist_album_sort_order_asc" type="id" />
+    <item name="action_artist_album_sort_order_desc" type="id" />
+    <item name="action_artist_album_sort_order_year" type="id" />
     <item name="action_artist_sort_order_asc" type="id" />
     <item name="action_artist_sort_order_desc" type="id" />
     <item name="action_song_sort_order_asc" type="id" />


### PR DESCRIPTION
The user can sort an Artist's albums to A-Z, Z-A and Year(asc), though the setting is not persisted. I use the app on a daily basis and I kinda miss this functionality.

I will add persistence to Shared Prefs if the feature is considered useful!