### PR TITLE
Disable clear menu item on NotRecentlyPlayed

### DIFF
--- a/app/src/main/java/com/kabouzeid/gramophone/adapter/PlaylistAdapter.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/adapter/PlaylistAdapter.java
@@ -245,7 +245,9 @@ public class PlaylistAdapter extends AbsMultiSelectAdapter<PlaylistAdapter.ViewH
                     if (playlist instanceof AbsSmartPlaylist) {
                         popupMenu.inflate(R.menu.menu_item_smart_playlist);
                         final AbsSmartPlaylist smartPlaylist = (AbsSmartPlaylist) playlist;
-                        popupMenu.getMenu().findItem(R.id.action_clear_playlist).setVisible(smartPlaylist.isClearable());
+                        if (!smartPlaylist.isClearable()) {
+                            popupMenu.getMenu().findItem(R.id.action_clear_playlist).setVisible(false);
+                        }
                         popupMenu.setOnMenuItemClickListener(item -> {
                             if (item.getItemId() == R.id.action_clear_playlist) {
                                 ClearSmartPlaylistDialog.create(smartPlaylist).show(activity.getSupportFragmentManager(), "CLEAR_SMART_PLAYLIST_" + smartPlaylist.name);
@@ -255,7 +257,7 @@ public class PlaylistAdapter extends AbsMultiSelectAdapter<PlaylistAdapter.ViewH
                                 activity, dataSet.get(getAdapterPosition()), item);
                         });
                     }
-					else {
+                    else {
                         popupMenu.inflate(R.menu.menu_item_playlist);
                         popupMenu.setOnMenuItemClickListener(item -> {
                             return PlaylistMenuHelper.handleMenuClick(

--- a/app/src/main/java/com/kabouzeid/gramophone/model/smartplaylist/AbsSmartPlaylist.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/model/smartplaylist/AbsSmartPlaylist.java
@@ -27,6 +27,10 @@ public abstract class AbsSmartPlaylist extends AbsCustomPlaylist {
 
     public abstract void clear(Context context);
 
+    public boolean isClearable() {
+        return true;
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;

--- a/app/src/main/java/com/kabouzeid/gramophone/model/smartplaylist/LastAddedPlaylist.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/model/smartplaylist/LastAddedPlaylist.java
@@ -29,6 +29,10 @@ public class LastAddedPlaylist extends AbsSmartPlaylist {
     public void clear(@NonNull Context context) {
     }
 
+    @Override
+    public boolean isClearable() {
+        return false;
+    }
 
     @Override
     public int describeContents() {

--- a/app/src/main/java/com/kabouzeid/gramophone/model/smartplaylist/NotRecentlyPlayedPlaylist.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/model/smartplaylist/NotRecentlyPlayedPlaylist.java
@@ -28,9 +28,12 @@ public class NotRecentlyPlayedPlaylist extends AbsSmartPlaylist {
 
     @Override
     public void clear(@NonNull Context context) {
-        HistoryStore.getInstance(context).clear();
     }
 
+    @Override
+    public boolean isClearable() {
+        return false;
+    }
 
     @Override
     public int describeContents() {


### PR DESCRIPTION
As of the case of LastAddedItem, the Clear action on the playlist NotRecentlyPlayed is not make sense.
This PR remove it from the popup menu.

Some refactoring is done on the playlist popup menu builder, to isolate plain playlist menu code from smart ones.