### PR TITLE
Finish current music when Sleep Timer stops

### DIFF
--- a/app/src/main/java/com/kabouzeid/gramophone/dialogs/SleepTimerDialog.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/dialogs/SleepTimerDialog.java
@@ -108,7 +108,7 @@ public class SleepTimerDialog extends DialogFragment {
 
                     PendingIntent pi = makeTimerPendingIntent(PendingIntent.FLAG_CANCEL_CURRENT);
 
-                    final long nextSleepTimerElapsedTime = SystemClock.elapsedRealtime() + minutes * 1000;
+                    final long nextSleepTimerElapsedTime = SystemClock.elapsedRealtime() + minutes * 60 * 1000;
                     PreferenceUtil.getInstance(getActivity()).setNextSleepTimerElapsedRealtime(nextSleepTimerElapsedTime);
                     AlarmManager am = (AlarmManager) getActivity().getSystemService(Context.ALARM_SERVICE);
                     am.set(AlarmManager.ELAPSED_REALTIME_WAKEUP, nextSleepTimerElapsedTime, pi);

--- a/app/src/main/java/com/kabouzeid/gramophone/dialogs/SleepTimerDialog.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/dialogs/SleepTimerDialog.java
@@ -24,6 +24,7 @@ import com.afollestad.materialdialogs.MaterialDialog;
 import com.afollestad.materialdialogs.internal.ThemeSingleton;
 import com.kabouzeid.gramophone.App;
 import com.kabouzeid.gramophone.R;
+import com.kabouzeid.gramophone.helper.MusicPlayerRemote;
 import com.kabouzeid.gramophone.service.MusicService;
 import com.kabouzeid.gramophone.ui.activities.PurchaseActivity;
 import com.kabouzeid.gramophone.util.MusicUtil;
@@ -47,37 +48,6 @@ public class SleepTimerDialog extends DialogFragment {
     private int seekArcProgress;
     private MaterialDialog materialDialog;
     private TimerUpdater timerUpdater;
-
-    private MusicService mMusicService = null;
-    private ServiceConnection mConnection = new ServiceConnection() {
-        @Override
-        public void onServiceConnected(ComponentName name, IBinder service) {
-            MusicService.MusicBinder binder = (MusicService.MusicBinder) service;
-            mMusicService = binder.getService();
-
-            updateCancelButton();
-        }
-
-        @Override
-        public void onServiceDisconnected(ComponentName name) {
-            mMusicService = null;
-        }
-    };
-
-    @Override
-    public void onStart() {
-        super.onStart();
-        Intent intent = new Intent(getContext(), MusicService.class);
-        getActivity().bindService(intent, mConnection, Context.BIND_AUTO_CREATE);
-    }
-
-    @Override
-    public void onStop() {
-        super.onStop();
-        if (mMusicService != null) {
-            getActivity().unbindService(mConnection);
-        }
-    }
 
     @Override
     public void onDismiss(DialogInterface dialog) {
@@ -127,8 +97,9 @@ public class SleepTimerDialog extends DialogFragment {
                         Toast.makeText(getActivity(), getActivity().getResources().getString(R.string.sleep_timer_canceled), Toast.LENGTH_SHORT).show();
                     }
 
-                    if (mMusicService != null && mMusicService.pendingQuit) {
-                        mMusicService.pendingQuit = false;
+                    MusicService musicService = MusicPlayerRemote.musicService;
+                    if (musicService != null && musicService.pendingQuit) {
+                        musicService.pendingQuit = false;
                         Toast.makeText(getActivity(), getActivity().getResources().getString(R.string.sleep_timer_canceled), Toast.LENGTH_SHORT).show();
                     }
                 })
@@ -208,7 +179,8 @@ public class SleepTimerDialog extends DialogFragment {
     }
 
     private void updateCancelButton() {
-        if (mMusicService != null && mMusicService.pendingQuit) {
+        MusicService musicService = MusicPlayerRemote.musicService;
+        if (musicService != null && musicService.pendingQuit) {
             materialDialog.setActionButton(DialogAction.NEUTRAL, materialDialog.getContext().getString(R.string.cancel_current_timer));
         } else {
             materialDialog.setActionButton(DialogAction.NEUTRAL, null);

--- a/app/src/main/java/com/kabouzeid/gramophone/dialogs/SleepTimerDialog.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/dialogs/SleepTimerDialog.java
@@ -41,8 +41,8 @@ public class SleepTimerDialog extends DialogFragment {
     SeekArc seekArc;
     @BindView(R.id.timer_display)
     TextView timerDisplay;
-    @BindView(R.id.checkBox)
-    CheckBox checkBox;
+    @BindView(R.id.should_finish_last_song)
+    CheckBox should_finish_last_song;
 
     private int seekArcProgress;
     private MaterialDialog materialDialog;
@@ -55,7 +55,7 @@ public class SleepTimerDialog extends DialogFragment {
             MusicService.MusicBinder binder = (MusicService.MusicBinder) service;
             mMusicService = binder.getService();
 
-            UpdateCancelButton();
+            updateCancelButton();
         }
 
         @Override
@@ -102,7 +102,7 @@ public class SleepTimerDialog extends DialogFragment {
                         return;
                     }
 
-                    PreferenceUtil.getInstance(getActivity()).setSleepTimerFinishMusic(checkBox.isChecked());
+                    PreferenceUtil.getInstance(getActivity()).setSleepTimerFinishMusic(should_finish_last_song.isChecked());
 
                     final int minutes = seekArcProgress;
 
@@ -146,8 +146,8 @@ public class SleepTimerDialog extends DialogFragment {
 
         ButterKnife.bind(this, materialDialog.getCustomView());
 
-        boolean checked = PreferenceUtil.getInstance(getActivity()).getSleepTimerFinishMusic();
-        checkBox.setChecked(checked);
+        boolean finishMusic = PreferenceUtil.getInstance(getActivity()).getSleepTimerFinishMusic();
+        should_finish_last_song.setChecked(finishMusic);
 
         seekArc.setProgressColor(ThemeSingleton.get().positiveColor.getDefaultColor());
         seekArc.setThumbColor(ThemeSingleton.get().positiveColor.getDefaultColor());
@@ -200,15 +200,14 @@ public class SleepTimerDialog extends DialogFragment {
     }
 
     private Intent makeTimerIntent() {
-        if (checkBox.isChecked()) {
-            return new Intent(getActivity(), MusicService.class)
-                    .setAction(MusicService.ACTION_PENDING_QUIT);
+        Intent intent = new Intent(getActivity(), MusicService.class);
+        if (should_finish_last_song.isChecked()) {
+            return intent.setAction(MusicService.ACTION_PENDING_QUIT);
         }
-        return new Intent(getActivity(), MusicService.class)
-                .setAction(MusicService.ACTION_QUIT);
+        return intent.setAction(MusicService.ACTION_QUIT);
     }
 
-    private void UpdateCancelButton() {
+    private void updateCancelButton() {
         if (mMusicService != null && mMusicService.pendingQuit) {
             materialDialog.setActionButton(DialogAction.NEUTRAL, materialDialog.getContext().getString(R.string.cancel_current_timer));
         } else {
@@ -228,7 +227,7 @@ public class SleepTimerDialog extends DialogFragment {
 
         @Override
         public void onFinish() {
-            UpdateCancelButton();
+            updateCancelButton();
         }
     }
 }

--- a/app/src/main/java/com/kabouzeid/gramophone/dialogs/SleepTimerDialog.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/dialogs/SleepTimerDialog.java
@@ -3,14 +3,11 @@ package com.kabouzeid.gramophone.dialogs;
 import android.app.AlarmManager;
 import android.app.Dialog;
 import android.app.PendingIntent;
-import android.content.ComponentName;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.content.ServiceConnection;
 import android.os.Bundle;
 import android.os.CountDownTimer;
-import android.os.IBinder;
 import android.os.SystemClock;
 import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
@@ -43,7 +40,7 @@ public class SleepTimerDialog extends DialogFragment {
     @BindView(R.id.timer_display)
     TextView timerDisplay;
     @BindView(R.id.should_finish_last_song)
-    CheckBox should_finish_last_song;
+    CheckBox shouldFinishLastSong;
 
     private int seekArcProgress;
     private MaterialDialog materialDialog;
@@ -72,7 +69,7 @@ public class SleepTimerDialog extends DialogFragment {
                         return;
                     }
 
-                    PreferenceUtil.getInstance(getActivity()).setSleepTimerFinishMusic(should_finish_last_song.isChecked());
+                    PreferenceUtil.getInstance(getActivity()).setSleepTimerFinishMusic(shouldFinishLastSong.isChecked());
 
                     final int minutes = seekArcProgress;
 
@@ -118,7 +115,7 @@ public class SleepTimerDialog extends DialogFragment {
         ButterKnife.bind(this, materialDialog.getCustomView());
 
         boolean finishMusic = PreferenceUtil.getInstance(getActivity()).getSleepTimerFinishMusic();
-        should_finish_last_song.setChecked(finishMusic);
+        shouldFinishLastSong.setChecked(finishMusic);
 
         seekArc.setProgressColor(ThemeSingleton.get().positiveColor.getDefaultColor());
         seekArc.setThumbColor(ThemeSingleton.get().positiveColor.getDefaultColor());
@@ -172,7 +169,7 @@ public class SleepTimerDialog extends DialogFragment {
 
     private Intent makeTimerIntent() {
         Intent intent = new Intent(getActivity(), MusicService.class);
-        if (should_finish_last_song.isChecked()) {
+        if (shouldFinishLastSong.isChecked()) {
             return intent.setAction(MusicService.ACTION_PENDING_QUIT);
         }
         return intent.setAction(MusicService.ACTION_QUIT);

--- a/app/src/main/java/com/kabouzeid/gramophone/service/MusicService.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/service/MusicService.java
@@ -83,6 +83,7 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
     public static final String ACTION_SKIP = PHONOGRAPH_PACKAGE_NAME + ".skip";
     public static final String ACTION_REWIND = PHONOGRAPH_PACKAGE_NAME + ".rewind";
     public static final String ACTION_QUIT = PHONOGRAPH_PACKAGE_NAME + ".quitservice";
+    public static final String ACTION_PENDING_QUIT = PHONOGRAPH_PACKAGE_NAME + ".pendingquitservice";
     public static final String INTENT_EXTRA_PLAYLIST = PHONOGRAPH_PACKAGE_NAME + "intentextra.playlist";
     public static final String INTENT_EXTRA_SHUFFLE_MODE = PHONOGRAPH_PACKAGE_NAME + ".intentextra.shufflemode";
 
@@ -124,6 +125,8 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
     public static final int SAVE_QUEUES = 0;
 
     private final IBinder musicBind = new MusicBinder();
+
+    public boolean pendingQuit = false;
 
     private AppWidgetBig appWidgetBig = AppWidgetBig.getInstance();
     private AppWidgetClassic appWidgetClassic = AppWidgetClassic.getInstance();
@@ -335,7 +338,11 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
                         break;
                     case ACTION_STOP:
                     case ACTION_QUIT:
+                        pendingQuit = false;
                         quit();
+                        break;
+                    case ACTION_PENDING_QUIT:
+                        pendingQuit = true;
                         break;
                 }
             }
@@ -1193,9 +1200,16 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
                     break;
 
                 case TRACK_ENDED:
-                    if (service.getRepeatMode() == REPEAT_MODE_NONE && service.isLastTrack()) {
+                    // if there is a timer finished, don't continue
+                    if (service.pendingQuit ||
+                            service.getRepeatMode() == REPEAT_MODE_NONE && service.isLastTrack()) {
                         service.notifyChange(PLAY_STATE_CHANGED);
                         service.seek(0);
+                        if (service.pendingQuit) {
+                            service.pendingQuit = false;
+                            service.quit();
+                            break;
+                        }
                     } else {
                         service.playNextSong(false);
                     }

--- a/app/src/main/java/com/kabouzeid/gramophone/util/PreferenceUtil.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/util/PreferenceUtil.java
@@ -67,6 +67,7 @@ public final class PreferenceUtil {
 
     public static final String LAST_SLEEP_TIMER_VALUE = "last_sleep_timer_value";
     public static final String NEXT_SLEEP_TIMER_ELAPSED_REALTIME = "next_sleep_timer_elapsed_real_time";
+    public static final String TIMER_FINISH_MUSIC = "sleep_timer_finish_music";
 
     public static final String IGNORE_MEDIA_STORE_ARTWORK = "ignore_media_store_artwork";
 
@@ -328,6 +329,16 @@ public final class PreferenceUtil {
     public void setNextSleepTimerElapsedRealtime(final long value) {
         final SharedPreferences.Editor editor = mPreferences.edit();
         editor.putLong(NEXT_SLEEP_TIMER_ELAPSED_REALTIME, value);
+        editor.apply();
+    }
+
+    public boolean getSleepTimerFinishMusic() {
+        return mPreferences.getBoolean(TIMER_FINISH_MUSIC, false);
+    }
+
+    public void setSleepTimerFinishMusic(final boolean value) {
+        final SharedPreferences.Editor editor = mPreferences.edit();
+        editor.putBoolean(TIMER_FINISH_MUSIC, value);
         editor.apply();
     }
 

--- a/app/src/main/java/com/kabouzeid/gramophone/util/PreferenceUtil.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/util/PreferenceUtil.java
@@ -67,7 +67,7 @@ public final class PreferenceUtil {
 
     public static final String LAST_SLEEP_TIMER_VALUE = "last_sleep_timer_value";
     public static final String NEXT_SLEEP_TIMER_ELAPSED_REALTIME = "next_sleep_timer_elapsed_real_time";
-    public static final String TIMER_FINISH_MUSIC = "sleep_timer_finish_music";
+    public static final String SLEEP_TIMER_FINISH_SONG = "sleep_timer_finish_music";
 
     public static final String IGNORE_MEDIA_STORE_ARTWORK = "ignore_media_store_artwork";
 
@@ -333,12 +333,12 @@ public final class PreferenceUtil {
     }
 
     public boolean getSleepTimerFinishMusic() {
-        return mPreferences.getBoolean(TIMER_FINISH_MUSIC, false);
+        return mPreferences.getBoolean(SLEEP_TIMER_FINISH_SONG, false);
     }
 
     public void setSleepTimerFinishMusic(final boolean value) {
         final SharedPreferences.Editor editor = mPreferences.edit();
-        editor.putBoolean(TIMER_FINISH_MUSIC, value);
+        editor.putBoolean(SLEEP_TIMER_FINISH_SONG, value);
         editor.apply();
     }
 

--- a/app/src/main/res/layout/dialog_sleep_timer.xml
+++ b/app/src/main/res/layout/dialog_sleep_timer.xml
@@ -1,27 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:seekarc="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
 
-    <com.triggertrap.seekarc.SeekArc
-        android:id="@+id/seek_arc"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:padding="30dp"
-        seekarc:SeekArc_clockwise="false"
-        seekarc:SeekArc_max="120"
-        seekarc:SeekArc_progressColor="?colorAccent"
-        seekarc:SeekArc_rotation="180"
-        seekarc:SeekArc_startAngle="30"
-        seekarc:SeekArc_sweepAngle="300" />
-
-    <LinearLayout
+    <FrameLayout
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:orientation="vertical">
+        android:layout_height="wrap_content">
+
+        <com.triggertrap.seekarc.SeekArc
+            android:id="@+id/seek_arc"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:padding="30dp"
+            seekarc:SeekArc_clockwise="false"
+            seekarc:SeekArc_max="120"
+            seekarc:SeekArc_progressColor="?colorAccent"
+            seekarc:SeekArc_rotation="180"
+            seekarc:SeekArc_startAngle="30"
+            seekarc:SeekArc_sweepAngle="300" />
 
         <TextView
             android:id="@+id/timer_display"
@@ -29,14 +28,14 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:textAppearance="?android:textAppearanceLarge" />
+    </FrameLayout>
 
-        <CheckBox
-            android:id="@+id/checkBox"
-            android:layout_width="wrap_content"
-            android:layout_height="42dp"
-            android:layout_gravity="bottom|center_horizontal"
-            android:text="@string/finish_current_music_sleep_timer" />
-    </LinearLayout>
+    <CheckBox
+        android:id="@+id/checkBox"
+        android:layout_width="wrap_content"
+        android:layout_height="42dp"
+        android:layout_gravity="bottom|center_horizontal"
+        android:text="@string/finish_current_music_sleep_timer" />
 
-</FrameLayout>
+</LinearLayout>
 

--- a/app/src/main/res/layout/dialog_sleep_timer.xml
+++ b/app/src/main/res/layout/dialog_sleep_timer.xml
@@ -17,12 +17,26 @@
         seekarc:SeekArc_startAngle="30"
         seekarc:SeekArc_sweepAngle="300" />
 
-    <TextView
-        android:id="@+id/timer_display"
+    <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
-        android:textAppearance="?android:textAppearanceLarge" />
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/timer_display"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:textAppearance="?android:textAppearanceLarge" />
+
+        <CheckBox
+            android:id="@+id/checkBox"
+            android:layout_width="wrap_content"
+            android:layout_height="42dp"
+            android:layout_gravity="bottom|center_horizontal"
+            android:text="@string/finish_current_music_sleep_timer" />
+    </LinearLayout>
 
 </FrameLayout>
 

--- a/app/src/main/res/layout/dialog_sleep_timer.xml
+++ b/app/src/main/res/layout/dialog_sleep_timer.xml
@@ -28,13 +28,15 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:textAppearance="?android:textAppearanceLarge" />
+
     </FrameLayout>
 
     <CheckBox
-        android:id="@+id/checkBox"
+        android:id="@+id/should_finish_last_song"
         android:layout_width="wrap_content"
         android:layout_height="42dp"
-        android:layout_gravity="bottom|center_horizontal"
+        android:layout_gravity="bottom"
+        android:layout_margin="30dp"
         android:text="@string/finish_current_music_sleep_timer" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_sleep_timer.xml
+++ b/app/src/main/res/layout/dialog_sleep_timer.xml
@@ -31,7 +31,7 @@
 
     </FrameLayout>
 
-    <CheckBox
+    <com.kabouzeid.appthemehelper.common.views.ATECheckBox
         android:id="@+id/should_finish_last_song"
         android:layout_width="wrap_content"
         android:layout_height="42dp"

--- a/app/src/main/res/layout/dialog_sleep_timer.xml
+++ b/app/src/main/res/layout/dialog_sleep_timer.xml
@@ -36,7 +36,7 @@
         android:layout_width="wrap_content"
         android:layout_height="42dp"
         android:layout_gravity="bottom"
-        android:layout_margin="30dp"
+        android:layout_margin="20dp"
         android:text="@string/finish_current_music_sleep_timer" />
 
 </LinearLayout>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -294,4 +294,5 @@
     <string name="sort_order_artist">艺术家</string>
     <string name="sort_order_album">专辑</string>
     <string name="sort_order_year">年份</string>
+    <string name="finish_current_music_sleep_timer">播完当前音乐再停止</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -294,5 +294,5 @@
     <string name="sort_order_artist">艺术家</string>
     <string name="sort_order_album">专辑</string>
     <string name="sort_order_year">年份</string>
-    <string name="finish_current_music_sleep_timer">播完当前音乐再停止</string>
+    <string name="finish_current_music_sleep_timer">播完当前音乐</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -312,4 +312,5 @@
     <string name="sort_order_artist">Artist</string>
     <string name="sort_order_album">Album</string>
     <string name="sort_order_year">Year</string>
+    <string name="finish_current_music_sleep_timer">Finish current music when Sleep Timer stops</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -312,5 +312,5 @@
     <string name="sort_order_artist">Artist</string>
     <string name="sort_order_album">Album</string>
     <string name="sort_order_year">Year</string>
-    <string name="finish_current_music_sleep_timer">Finish current music when Sleep Timer stops</string>
+    <string name="finish_current_music_sleep_timer">Finish last song</string>
 </resources>


### PR DESCRIPTION
Implement #329.
This commit adds a CheckBox to dialog_sleep_timer, and a curresponding
option `TIMER_FINISH_MUSIC` in PreferenceUtil.

In MusicService, a new flag `pendingQuit` is to indicate if it should
stop after current music stops. A new action `ACTION_PENDING_QUIT` will
set that flag.

Canceling is a little tricky. I must bind MusicService in Dialog
activity to check if `pendingQuit` is set, and show the corresponding
canceling button.