### PR TITLE
Remove various SQLite-related hard-coded limits

### DIFF
--- a/app/src/main/java/com/kabouzeid/gramophone/helper/SearchQueryHelper.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/helper/SearchQueryHelper.java
@@ -71,7 +71,6 @@ public class SearchQueryHelper {
             return songs;
         }
 
-
         songs = SongLoader.getSongs(SongLoader.makeSongCursor(context, ARTIST_SELECTION, new String[]{query.toLowerCase().trim()}));
         if (!songs.isEmpty()) {
             return songs;

--- a/app/src/main/java/com/kabouzeid/gramophone/loader/SongLoader.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/loader/SongLoader.java
@@ -112,12 +112,13 @@ public class SongLoader {
         // Blacklist
         ArrayList<String> paths = BlacklistStore.getInstance(context).getPaths();
         if (!paths.isEmpty()) {
-            // TODO sqlite limits the ?argument count to 1000
+            // TODO sqlite limits the ?argument count to 999
             selection = generateBlacklistSelection(selection, paths.size());
             selectionValues = addBlacklistSelectionValues(selectionValues, paths);
         }
 
         try {
+            // TODO sqlite limit the query length to 1000000 bytes
             return context.getContentResolver().query(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
                     BASE_PROJECTION, selection, selectionValues, sortOrder);
         } catch (SecurityException e) {

--- a/app/src/main/java/com/kabouzeid/gramophone/loader/SongLoader.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/loader/SongLoader.java
@@ -112,6 +112,7 @@ public class SongLoader {
         // Blacklist
         ArrayList<String> paths = BlacklistStore.getInstance(context).getPaths();
         if (!paths.isEmpty()) {
+            // TODO sqlite limits the ?argument count to 1000
             selection = generateBlacklistSelection(selection, paths.size());
             selectionValues = addBlacklistSelectionValues(selectionValues, paths);
         }

--- a/app/src/main/java/com/kabouzeid/gramophone/loader/TopAndRecentlyPlayedTracksLoader.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/loader/TopAndRecentlyPlayedTracksLoader.java
@@ -31,7 +31,7 @@ import com.kabouzeid.gramophone.util.PreferenceUtil;
 import java.util.ArrayList;
 
 public class TopAndRecentlyPlayedTracksLoader {
-    public static final int NUMBER_OF_TOP_TRACKS = 100;
+    public static final int NUMBER_OF_TOP_TRACKS = 99;
 
     @NonNull
     public static ArrayList<Song> getRecentlyPlayedTracks(@NonNull Context context) {

--- a/app/src/main/java/com/kabouzeid/gramophone/provider/HistoryStore.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/provider/HistoryStore.java
@@ -25,8 +25,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 public class HistoryStore extends SQLiteOpenHelper {
-    private static final int MAX_ITEMS_IN_DB = 5000; // TODO Remove this limit
-
     public static final String DATABASE_NAME = "history.db";
     private static final int VERSION = 1;
     @Nullable
@@ -80,28 +78,6 @@ public class HistoryStore extends SQLiteOpenHelper {
             values.put(RecentStoreColumns.ID, songId);
             values.put(RecentStoreColumns.TIME_PLAYED, System.currentTimeMillis());
             database.insert(RecentStoreColumns.NAME, null, values);
-
-            // if our db is too large, delete the extra items
-            Cursor oldest = null;
-            try {
-                oldest = database.query(RecentStoreColumns.NAME,
-                        new String[]{RecentStoreColumns.TIME_PLAYED}, null, null, null, null,
-                        RecentStoreColumns.TIME_PLAYED + " ASC");
-
-                if (oldest != null && oldest.getCount() > MAX_ITEMS_IN_DB) {
-                    oldest.moveToPosition(oldest.getCount() - MAX_ITEMS_IN_DB);
-                    long timeOfRecordToKeep = oldest.getLong(0);
-
-                    database.delete(RecentStoreColumns.NAME,
-                            RecentStoreColumns.TIME_PLAYED + " < ?",
-                            new String[]{String.valueOf(timeOfRecordToKeep)});
-
-                }
-            } finally {
-                if (oldest != null) {
-                    oldest.close();
-                }
-            }
         } finally {
             database.setTransactionSuccessful();
             database.endTransaction();

--- a/app/src/main/java/com/kabouzeid/gramophone/provider/HistoryStore.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/provider/HistoryStore.java
@@ -25,7 +25,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 public class HistoryStore extends SQLiteOpenHelper {
-    private static final int MAX_ITEMS_IN_DB = 5000;
+    private static final int MAX_ITEMS_IN_DB = 5000; // TODO Remove this limit
 
     public static final String DATABASE_NAME = "history.db";
     private static final int VERSION = 1;

--- a/app/src/main/java/com/kabouzeid/gramophone/util/FileUtil.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/util/FileUtil.java
@@ -38,41 +38,22 @@ public final class FileUtil {
 
     @Nullable
     public static SortedCursor makeSongCursor(@NonNull final Context context, @Nullable final List<File> files) {
-        String selection = null;
-        String[] paths = null;
-
+        ArrayList<String> paths = new ArrayList<String>();
         if (files != null) {
             paths = toPathArray(files);
-
-            if (files.size() > 0 && files.size() < 999) { // TODO 999 is the max amount Androids SQL implementation can handle.
-                selection = MediaStore.Audio.AudioColumns.DATA + " IN (" + makePlaceholders(files.size()) + ")";
-            }
         }
 
-        Cursor songCursor = SongLoader.makeSongCursor(context, selection, selection == null ? null : paths);
-
-        return songCursor == null ? null : new SortedCursor(songCursor, paths, MediaStore.Audio.AudioColumns.DATA);
-    }
-
-    private static String makePlaceholders(int len) {
-        StringBuilder sb = new StringBuilder(len * 2 - 1);
-        sb.append("?");
-        for (int i = 1; i < len; i++) {
-            sb.append(",?");
-        }
-        return sb.toString();
+        Cursor songCursor = SongLoader.makeSongCursorFromPaths(context, paths);
+        return songCursor == null ? null : new SortedCursor(songCursor, paths.toArray(new String[paths.size()]), MediaStore.Audio.AudioColumns.DATA);
     }
 
     @Nullable
-    private static String[] toPathArray(@Nullable List<File> files) {
-        if (files != null) {
-            String[] paths = new String[files.size()];
-            for (int i = 0; i < files.size(); i++) {
-                paths[i] = safeGetCanonicalPath(files.get(i));
-            }
-            return paths;
+    private static ArrayList<String> toPathArray(@Nullable List<File> files) {
+        ArrayList<String> paths = new ArrayList<String>(files.size());
+        for (int i = 0; i < files.size(); i++) {
+            paths.set(i, safeGetCanonicalPath(files.get(i)));
         }
-        return null;
+        return paths;
     }
 
     @NonNull

--- a/app/src/main/java/com/kabouzeid/gramophone/util/FileUtil.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/util/FileUtil.java
@@ -44,7 +44,7 @@ public final class FileUtil {
         if (files != null) {
             paths = toPathArray(files);
 
-            if (files.size() > 0 && files.size() < 999) { // 999 is the max amount Androids SQL implementation can handle.
+            if (files.size() > 0 && files.size() < 999) { // TODO 999 is the max amount Androids SQL implementation can handle.
                 selection = MediaStore.Audio.AudioColumns.DATA + " IN (" + makePlaceholders(files.size()) + ")";
             }
         }

--- a/app/src/main/java/com/kabouzeid/gramophone/util/MusicUtil.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/util/MusicUtil.java
@@ -259,10 +259,9 @@ public class MusicUtil {
                 BaseColumns._ID, MediaStore.MediaColumns.DATA
         };
 
-        // SQLite limits the query length to 1000000 bytes
         // Split the query into multiple batches, and merge the resulting cursors
         int songIndex = 0;
-        final int batchSize = 5000; // arbitrary value, assuming the batchSize * avg_len(song.id) < limit
+        final int batchSize = 1000000 / 10; // 10^6 being the SQLite limite on the query lenth in bytes, 10 being the max number of digits in an int, used to store the track ID
         final int songCount = songs.size();
 
         while (songIndex < songCount)

--- a/app/src/main/java/com/kabouzeid/gramophone/util/MusicUtil.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/util/MusicUtil.java
@@ -258,6 +258,7 @@ public class MusicUtil {
         final String[] projection = new String[]{
                 BaseColumns._ID, MediaStore.MediaColumns.DATA
         };
+        // TODO sqlite limits the query length
         final StringBuilder selection = new StringBuilder();
         selection.append(BaseColumns._ID + " IN (");
         for (int i = 0; i < songs.size(); i++) {


### PR DESCRIPTION
- Multiples workarounds for SQLite
  - Remove the limit of 999 '?' arguments per statement (potentially fixes the bug https://github.com/kabouzeid/Phonograph/issues/594)
  - Avoid the (hypothetical) 1Mb statement size.

- ~~The number of top tracks is increase from 99 to 100 (why 99 by the way?)~~

- Lift the limit of 5000 on the history DB size. Now the size of this DB is capped by the number of tracks in the library.
