### PR TITLE
Refactoring: Replace usages of ArrayList<> with List<>Collections refactor

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -88,7 +88,7 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.core:core:1.0.2'
+    implementation 'androidx.core:core:1.0.1'
     implementation 'androidx.legacy:legacy-support-core-utils:1.0.0'
     implementation 'androidx.legacy:legacy-support-core-ui:1.0.0'
     implementation 'androidx.media:media:1.0.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -88,7 +88,7 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.core:core:1.0.1'
+    implementation 'androidx.core:core:1.0.2'
     implementation 'androidx.legacy:legacy-support-core-utils:1.0.0'
     implementation 'androidx.legacy:legacy-support-core-ui:1.0.0'
     implementation 'androidx.media:media:1.0.1'

--- a/app/src/main/java/com/kabouzeid/gramophone/App.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/App.java
@@ -2,6 +2,7 @@ package com.kabouzeid.gramophone;
 
 import android.app.Application;
 import android.os.Build;
+
 import androidx.annotation.NonNull;
 
 import com.anjlab.android.iab.v3.BillingProcessor;
@@ -62,7 +63,7 @@ public class App extends Application {
     }
 
     public static boolean isProVersion() {
-        return BuildConfig.DEBUG || app.billingProcessor.isPurchased(PRO_VERSION_PRODUCT_ID);
+        return true;
     }
 
     public static App getInstance() {

--- a/app/src/main/java/com/kabouzeid/gramophone/App.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/App.java
@@ -63,7 +63,7 @@ public class App extends Application {
     }
 
     public static boolean isProVersion() {
-        return true;
+        return BuildConfig.DEBUG || app.billingProcessor.isPurchased(PRO_VERSION_PRODUCT_ID);
     }
 
     public static App getInstance() {

--- a/app/src/main/java/com/kabouzeid/gramophone/adapter/AlbumCoverPagerAdapter.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/adapter/AlbumCoverPagerAdapter.java
@@ -19,6 +19,7 @@ import com.kabouzeid.gramophone.model.Song;
 import com.kabouzeid.gramophone.util.PreferenceUtil;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -29,12 +30,12 @@ import butterknife.Unbinder;
  */
 public class AlbumCoverPagerAdapter extends CustomFragmentStatePagerAdapter {
 
-    private ArrayList<Song> dataSet;
+    private List<Song> dataSet;
 
     private AlbumCoverFragment.ColorReceiver currentColorReceiver;
     private int currentColorReceiverPosition = -1;
 
-    public AlbumCoverPagerAdapter(FragmentManager fm, ArrayList<Song> dataSet) {
+    public AlbumCoverPagerAdapter(FragmentManager fm, List<Song> dataSet) {
         super(fm);
         this.dataSet = dataSet;
     }

--- a/app/src/main/java/com/kabouzeid/gramophone/adapter/CategoryInfoAdapter.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/adapter/CategoryInfoAdapter.java
@@ -17,12 +17,13 @@ import com.kabouzeid.gramophone.model.CategoryInfo;
 import com.kabouzeid.gramophone.util.SwipeAndDragHelper;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class CategoryInfoAdapter extends RecyclerView.Adapter<CategoryInfoAdapter.ViewHolder> implements SwipeAndDragHelper.ActionCompletionContract {
-    private ArrayList<CategoryInfo> categoryInfos;
+    private List<CategoryInfo> categoryInfos;
     private ItemTouchHelper touchHelper;
 
-    public CategoryInfoAdapter(ArrayList<CategoryInfo> categoryInfos) {
+    public CategoryInfoAdapter(List<CategoryInfo> categoryInfos) {
         this.categoryInfos = categoryInfos;
         SwipeAndDragHelper swipeAndDragHelper = new SwipeAndDragHelper(this);
         touchHelper = new ItemTouchHelper(swipeAndDragHelper);
@@ -66,7 +67,7 @@ public class CategoryInfoAdapter extends RecyclerView.Adapter<CategoryInfoAdapte
         return categoryInfos.size();
     }
 
-    public void setCategoryInfos(ArrayList<CategoryInfo> categoryInfos) {
+    public void setCategoryInfos(List<CategoryInfo> categoryInfos) {
         this.categoryInfos = categoryInfos;
         notifyDataSetChanged();
     }
@@ -83,7 +84,7 @@ public class CategoryInfoAdapter extends RecyclerView.Adapter<CategoryInfoAdapte
         touchHelper.attachToRecyclerView(recyclerView);
     }
 
-    public ArrayList<CategoryInfo> getCategoryInfos() {
+    public List<CategoryInfo> getCategoryInfos() {
         return categoryInfos;
     }
 

--- a/app/src/main/java/com/kabouzeid/gramophone/adapter/GenreAdapter.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/adapter/GenreAdapter.java
@@ -15,25 +15,26 @@ import com.kabouzeid.gramophone.util.NavigationUtil;
 import com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class GenreAdapter extends RecyclerView.Adapter<GenreAdapter.ViewHolder> implements FastScrollRecyclerView.SectionedAdapter {
 
     @NonNull
     private final AppCompatActivity activity;
-    private ArrayList<Genre> dataSet;
+    private List<Genre> dataSet;
     private int itemLayoutRes;
 
-    public GenreAdapter(@NonNull AppCompatActivity activity, ArrayList<Genre> dataSet, @LayoutRes int itemLayoutRes) {
+    public GenreAdapter(@NonNull AppCompatActivity activity, List<Genre> dataSet, @LayoutRes int itemLayoutRes) {
         this.activity = activity;
         this.dataSet = dataSet;
         this.itemLayoutRes = itemLayoutRes;
     }
 
-    public ArrayList<Genre> getDataSet() {
+    public List<Genre> getDataSet() {
         return dataSet;
     }
 
-    public void swapDataSet(ArrayList<Genre> dataSet) {
+    public void swapDataSet(List<Genre> dataSet) {
         this.dataSet = dataSet;
         notifyDataSetChanged();
     }

--- a/app/src/main/java/com/kabouzeid/gramophone/adapter/MusicLibraryPagerAdapter.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/adapter/MusicLibraryPagerAdapter.java
@@ -38,7 +38,7 @@ public class MusicLibraryPagerAdapter extends FragmentPagerAdapter {
         setCategoryInfos(PreferenceUtil.getInstance(context).getLibraryCategoryInfos());
     }
 
-    public void setCategoryInfos(@NonNull ArrayList<CategoryInfo> categoryInfos) {
+    public void setCategoryInfos(@NonNull List<CategoryInfo> categoryInfos) {
         mHolderList.clear();
 
         for (CategoryInfo categoryInfo : categoryInfos) {

--- a/app/src/main/java/com/kabouzeid/gramophone/adapter/PlaylistAdapter.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/adapter/PlaylistAdapter.java
@@ -48,10 +48,10 @@ public class PlaylistAdapter extends AbsMultiSelectAdapter<PlaylistAdapter.ViewH
     private static final int DEFAULT_PLAYLIST = 1;
 
     protected final AppCompatActivity activity;
-    protected ArrayList<Playlist> dataSet;
+    protected List<Playlist> dataSet;
     protected int itemLayoutRes;
 
-    public PlaylistAdapter(AppCompatActivity activity, ArrayList<Playlist> dataSet, @LayoutRes int itemLayoutRes, @Nullable CabHolder cabHolder) {
+    public PlaylistAdapter(AppCompatActivity activity, List<Playlist> dataSet, @LayoutRes int itemLayoutRes, @Nullable CabHolder cabHolder) {
         super(activity, cabHolder, R.menu.menu_playlists_selection);
         this.activity = activity;
         this.dataSet = dataSet;
@@ -59,11 +59,11 @@ public class PlaylistAdapter extends AbsMultiSelectAdapter<PlaylistAdapter.ViewH
         setHasStableIds(true);
     }
 
-    public ArrayList<Playlist> getDataSet() {
+    public List<Playlist> getDataSet() {
         return dataSet;
     }
 
-    public void swapDataSet(ArrayList<Playlist> dataSet) {
+    public void swapDataSet(List<Playlist> dataSet) {
         this.dataSet = dataSet;
         notifyDataSetChanged();
     }
@@ -137,7 +137,7 @@ public class PlaylistAdapter extends AbsMultiSelectAdapter<PlaylistAdapter.ViewH
     }
 
     @Override
-    protected void onMultipleItemAction(@NonNull MenuItem menuItem, @NonNull ArrayList<Playlist> selection) {
+    protected void onMultipleItemAction(@NonNull MenuItem menuItem, @NonNull List<Playlist> selection) {
         switch (menuItem.getItemId()) {
             case R.id.action_delete_playlist:
                 for (int i = 0; i < selection.size(); i++) {
@@ -166,13 +166,13 @@ public class PlaylistAdapter extends AbsMultiSelectAdapter<PlaylistAdapter.ViewH
         }
     }
 
-    private static class SavePlaylistsAsyncTask extends WeakContextAsyncTask<ArrayList<Playlist>, String, String> {
+    private static class SavePlaylistsAsyncTask extends WeakContextAsyncTask<List<Playlist>, String, String> {
         public SavePlaylistsAsyncTask(Context context) {
             super(context);
         }
 
         @Override
-        protected String doInBackground(ArrayList<Playlist>... params) {
+        protected String doInBackground(List<Playlist>... params) {
             int successes = 0;
             int failures = 0;
 
@@ -204,8 +204,8 @@ public class PlaylistAdapter extends AbsMultiSelectAdapter<PlaylistAdapter.ViewH
     }
 
     @NonNull
-    private ArrayList<Song> getSongList(@NonNull List<Playlist> playlists) {
-        final ArrayList<Song> songs = new ArrayList<>();
+    private List<Song> getSongList(@NonNull List<Playlist> playlists) {
+        final List<Song> songs = new ArrayList<>();
         for (Playlist playlist : playlists) {
             if (playlist instanceof AbsCustomPlaylist) {
                 songs.addAll(((AbsCustomPlaylist) playlist).getSongs(activity));

--- a/app/src/main/java/com/kabouzeid/gramophone/adapter/SearchAdapter.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/adapter/SearchAdapter.java
@@ -164,7 +164,7 @@ public class SearchAdapter extends RecyclerView.Adapter<SearchAdapter.ViewHolder
                             ));
                     break;
                 case SONG:
-                    ArrayList<Song> playList = new ArrayList<>();
+                    List<Song> playList = new ArrayList<>();
                     playList.add((Song) item);
                     MusicPlayerRemote.openQueue(playList, 0, true);
                     break;

--- a/app/src/main/java/com/kabouzeid/gramophone/adapter/SongFileAdapter.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/adapter/SongFileAdapter.java
@@ -151,7 +151,7 @@ public class SongFileAdapter extends AbsMultiSelectAdapter<SongFileAdapter.ViewH
     }
 
     @Override
-    protected void onMultipleItemAction(MenuItem menuItem, ArrayList<File> selection) {
+    protected void onMultipleItemAction(MenuItem menuItem, List<File> selection) {
         if (callbacks == null) return;
         callbacks.onMultipleItemAction(menuItem, selection);
     }
@@ -206,6 +206,6 @@ public class SongFileAdapter extends AbsMultiSelectAdapter<SongFileAdapter.ViewH
 
         void onFileMenuClicked(File file, View view);
 
-        void onMultipleItemAction(MenuItem item, ArrayList<File> files);
+        void onMultipleItemAction(MenuItem item, List<File> files);
     }
 }

--- a/app/src/main/java/com/kabouzeid/gramophone/adapter/album/AlbumAdapter.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/adapter/album/AlbumAdapter.java
@@ -39,13 +39,13 @@ import java.util.List;
 public class AlbumAdapter extends AbsMultiSelectAdapter<AlbumAdapter.ViewHolder, Album> implements FastScrollRecyclerView.SectionedAdapter {
 
     protected final AppCompatActivity activity;
-    protected ArrayList<Album> dataSet;
+    protected List<Album> dataSet;
 
     protected int itemLayoutRes;
 
     protected boolean usePalette = false;
 
-    public AlbumAdapter(@NonNull AppCompatActivity activity, ArrayList<Album> dataSet, @LayoutRes int itemLayoutRes, boolean usePalette, @Nullable CabHolder cabHolder) {
+    public AlbumAdapter(@NonNull AppCompatActivity activity, List<Album> dataSet, @LayoutRes int itemLayoutRes, boolean usePalette, @Nullable CabHolder cabHolder) {
         super(activity, cabHolder, R.menu.menu_media_selection);
         this.activity = activity;
         this.dataSet = dataSet;
@@ -60,12 +60,12 @@ public class AlbumAdapter extends AbsMultiSelectAdapter<AlbumAdapter.ViewHolder,
         notifyDataSetChanged();
     }
 
-    public void swapDataSet(ArrayList<Album> dataSet) {
+    public void swapDataSet(List<Album> dataSet) {
         this.dataSet = dataSet;
         notifyDataSetChanged();
     }
 
-    public ArrayList<Album> getDataSet() {
+    public List<Album> getDataSet() {
         return dataSet;
     }
 
@@ -174,13 +174,13 @@ public class AlbumAdapter extends AbsMultiSelectAdapter<AlbumAdapter.ViewHolder,
     }
 
     @Override
-    protected void onMultipleItemAction(@NonNull MenuItem menuItem, @NonNull ArrayList<Album> selection) {
+    protected void onMultipleItemAction(@NonNull MenuItem menuItem, @NonNull List<Album> selection) {
         SongsMenuHelper.handleMenuClick(activity, getSongList(selection), menuItem.getItemId());
     }
 
     @NonNull
-    private ArrayList<Song> getSongList(@NonNull List<Album> albums) {
-        final ArrayList<Song> songs = new ArrayList<>();
+    private List<Song> getSongList(@NonNull List<Album> albums) {
+        final List<Song> songs = new ArrayList<>();
         for (Album album : albums) {
             songs.addAll(album.songs);
         }

--- a/app/src/main/java/com/kabouzeid/gramophone/adapter/album/HorizontalAlbumAdapter.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/adapter/album/HorizontalAlbumAdapter.java
@@ -19,13 +19,14 @@ import com.kabouzeid.gramophone.model.Album;
 import com.kabouzeid.gramophone.util.MusicUtil;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
  */
 public class HorizontalAlbumAdapter extends AlbumAdapter {
 
-    public HorizontalAlbumAdapter(@NonNull AppCompatActivity activity, ArrayList<Album> dataSet, boolean usePalette, @Nullable CabHolder cabHolder) {
+    public HorizontalAlbumAdapter(@NonNull AppCompatActivity activity, List<Album> dataSet, boolean usePalette, @Nullable CabHolder cabHolder) {
         super(activity, dataSet, HorizontalAdapterHelper.LAYOUT_RES, usePalette, cabHolder);
     }
 

--- a/app/src/main/java/com/kabouzeid/gramophone/adapter/artist/ArtistAdapter.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/adapter/artist/ArtistAdapter.java
@@ -38,13 +38,13 @@ import java.util.List;
 public class ArtistAdapter extends AbsMultiSelectAdapter<ArtistAdapter.ViewHolder, Artist> implements FastScrollRecyclerView.SectionedAdapter {
 
     protected final AppCompatActivity activity;
-    protected ArrayList<Artist> dataSet;
+    protected List<Artist> dataSet;
 
     protected int itemLayoutRes;
 
     protected boolean usePalette = false;
 
-    public ArtistAdapter(@NonNull AppCompatActivity activity, ArrayList<Artist> dataSet, @LayoutRes int itemLayoutRes, boolean usePalette, @Nullable CabHolder cabHolder) {
+    public ArtistAdapter(@NonNull AppCompatActivity activity, List<Artist> dataSet, @LayoutRes int itemLayoutRes, boolean usePalette, @Nullable CabHolder cabHolder) {
         super(activity, cabHolder, R.menu.menu_media_selection);
         this.activity = activity;
         this.dataSet = dataSet;
@@ -53,12 +53,12 @@ public class ArtistAdapter extends AbsMultiSelectAdapter<ArtistAdapter.ViewHolde
         setHasStableIds(true);
     }
 
-    public void swapDataSet(ArrayList<Artist> dataSet) {
+    public void swapDataSet(List<Artist> dataSet) {
         this.dataSet = dataSet;
         notifyDataSetChanged();
     }
 
-    public ArrayList<Artist> getDataSet() {
+    public List<Artist> getDataSet() {
         return dataSet;
     }
 
@@ -160,13 +160,13 @@ public class ArtistAdapter extends AbsMultiSelectAdapter<ArtistAdapter.ViewHolde
     }
 
     @Override
-    protected void onMultipleItemAction(@NonNull MenuItem menuItem, @NonNull ArrayList<Artist> selection) {
+    protected void onMultipleItemAction(@NonNull MenuItem menuItem, @NonNull List<Artist> selection) {
         SongsMenuHelper.handleMenuClick(activity, getSongList(selection), menuItem.getItemId());
     }
 
     @NonNull
-    private ArrayList<Song> getSongList(@NonNull List<Artist> artists) {
-        final ArrayList<Song> songs = new ArrayList<>();
+    private List<Song> getSongList(@NonNull List<Artist> artists) {
+        final List<Song> songs = new ArrayList<>();
         for (Artist artist : artists) {
             songs.addAll(artist.getSongs()); // maybe async in future?
         }

--- a/app/src/main/java/com/kabouzeid/gramophone/adapter/base/AbsMultiSelectAdapter.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/adapter/base/AbsMultiSelectAdapter.java
@@ -12,6 +12,7 @@ import com.kabouzeid.gramophone.R;
 import com.kabouzeid.gramophone.interfaces.CabHolder;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
@@ -20,7 +21,7 @@ public abstract class AbsMultiSelectAdapter<VH extends RecyclerView.ViewHolder, 
     @Nullable
     private final CabHolder cabHolder;
     private MaterialCab cab;
-    private ArrayList<I> checked;
+    private List<I> checked;
     private int menuRes;
     private final Context context;
 
@@ -118,5 +119,5 @@ public abstract class AbsMultiSelectAdapter<VH extends RecyclerView.ViewHolder, 
     @Nullable
     protected abstract I getIdentifier(int position);
 
-    protected abstract void onMultipleItemAction(MenuItem menuItem, ArrayList<I> selection);
+    protected abstract void onMultipleItemAction(MenuItem menuItem, List<I> selection);
 }

--- a/app/src/main/java/com/kabouzeid/gramophone/adapter/song/AbsOffsetSongAdapter.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/adapter/song/AbsOffsetSongAdapter.java
@@ -14,6 +14,7 @@ import com.kabouzeid.gramophone.interfaces.CabHolder;
 import com.kabouzeid.gramophone.model.Song;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Eugene Cheung (arkon)
@@ -23,11 +24,11 @@ public abstract class AbsOffsetSongAdapter extends SongAdapter {
     protected static final int OFFSET_ITEM = 0;
     protected static final int SONG = 1;
 
-    public AbsOffsetSongAdapter(AppCompatActivity activity, ArrayList<Song> dataSet, @LayoutRes int itemLayoutRes, boolean usePalette, @Nullable CabHolder cabHolder) {
+    public AbsOffsetSongAdapter(AppCompatActivity activity, List<Song> dataSet, @LayoutRes int itemLayoutRes, boolean usePalette, @Nullable CabHolder cabHolder) {
         super(activity, dataSet, itemLayoutRes, usePalette, cabHolder);
     }
 
-    public AbsOffsetSongAdapter(AppCompatActivity activity, ArrayList<Song> dataSet, @LayoutRes int itemLayoutRes, boolean usePalette, @Nullable CabHolder cabHolder, boolean showSectionName) {
+    public AbsOffsetSongAdapter(AppCompatActivity activity, List<Song> dataSet, @LayoutRes int itemLayoutRes, boolean usePalette, @Nullable CabHolder cabHolder, boolean showSectionName) {
         super(activity, dataSet, itemLayoutRes, usePalette, cabHolder, showSectionName);
     }
 

--- a/app/src/main/java/com/kabouzeid/gramophone/adapter/song/AlbumSongAdapter.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/adapter/song/AlbumSongAdapter.java
@@ -11,13 +11,14 @@ import com.kabouzeid.gramophone.model.Song;
 import com.kabouzeid.gramophone.util.MusicUtil;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
  */
 public class AlbumSongAdapter extends SongAdapter {
 
-    public AlbumSongAdapter(AppCompatActivity activity, ArrayList<Song> dataSet, @LayoutRes int itemLayoutRes, boolean usePalette, @Nullable CabHolder cabHolder) {
+    public AlbumSongAdapter(AppCompatActivity activity, List<Song> dataSet, @LayoutRes int itemLayoutRes, boolean usePalette, @Nullable CabHolder cabHolder) {
         super(activity, dataSet, itemLayoutRes, usePalette, cabHolder);
     }
 

--- a/app/src/main/java/com/kabouzeid/gramophone/adapter/song/ArtistSongAdapter.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/adapter/song/ArtistSongAdapter.java
@@ -26,6 +26,7 @@ import com.kabouzeid.gramophone.model.Song;
 import com.kabouzeid.gramophone.util.NavigationUtil;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
@@ -34,13 +35,13 @@ public class ArtistSongAdapter extends ArrayAdapter<Song> implements MaterialCab
     @Nullable
     private final CabHolder cabHolder;
     private MaterialCab cab;
-    private ArrayList<Song> dataSet;
-    private ArrayList<Song> checked;
+    private List<Song> dataSet;
+    private List<Song> checked;
 
     @NonNull
     private final AppCompatActivity activity;
 
-    public ArtistSongAdapter(@NonNull AppCompatActivity activity, @NonNull ArrayList<Song> dataSet, @Nullable CabHolder cabHolder) {
+    public ArtistSongAdapter(@NonNull AppCompatActivity activity, @NonNull List<Song> dataSet, @Nullable CabHolder cabHolder) {
         super(activity, R.layout.item_list, dataSet);
         this.activity = activity;
         this.cabHolder = cabHolder;
@@ -48,11 +49,11 @@ public class ArtistSongAdapter extends ArrayAdapter<Song> implements MaterialCab
         checked = new ArrayList<>();
     }
 
-    public ArrayList<Song> getDataSet() {
+    public List<Song> getDataSet() {
         return dataSet;
     }
 
-    public void swapDataSet(ArrayList<Song> dataSet) {
+    public void swapDataSet(List<Song> dataSet) {
         this.dataSet = dataSet;
         clear();
         addAll(dataSet);
@@ -129,7 +130,7 @@ public class ArtistSongAdapter extends ArrayAdapter<Song> implements MaterialCab
         return convertView;
     }
 
-    private void onMultipleItemAction(@NonNull MenuItem menuItem, @NonNull ArrayList<Song> selection) {
+    private void onMultipleItemAction(@NonNull MenuItem menuItem, @NonNull List<Song> selection) {
         SongsMenuHelper.handleMenuClick(activity, selection, menuItem.getItemId());
     }
 

--- a/app/src/main/java/com/kabouzeid/gramophone/adapter/song/OrderablePlaylistSongAdapter.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/adapter/song/OrderablePlaylistSongAdapter.java
@@ -29,8 +29,8 @@ public class OrderablePlaylistSongAdapter extends PlaylistSongAdapter implements
 
     private OnMoveItemListener onMoveItemListener;
 
-    public OrderablePlaylistSongAdapter(@NonNull AppCompatActivity activity, @NonNull ArrayList<PlaylistSong> dataSet, @LayoutRes int itemLayoutRes, boolean usePalette, @Nullable CabHolder cabHolder, @Nullable OnMoveItemListener onMoveItemListener) {
-        super(activity, (ArrayList<Song>) (List) dataSet, itemLayoutRes, usePalette, cabHolder);
+    public OrderablePlaylistSongAdapter(@NonNull AppCompatActivity activity, @NonNull List<PlaylistSong> dataSet, @LayoutRes int itemLayoutRes, boolean usePalette, @Nullable CabHolder cabHolder, @Nullable OnMoveItemListener onMoveItemListener) {
+        super(activity, (List<Song>) (List) dataSet, itemLayoutRes, usePalette, cabHolder);
         setMultiSelectMenuRes(R.menu.menu_playlists_songs_selection);
         this.onMoveItemListener = onMoveItemListener;
     }
@@ -44,14 +44,14 @@ public class OrderablePlaylistSongAdapter extends PlaylistSongAdapter implements
     public long getItemId(int position) {
         position--;
         if (position < 0) return -2;
-        return ((ArrayList<PlaylistSong>) (List) dataSet).get(position).idInPlayList; // important!
+        return ((List<PlaylistSong>) (List) dataSet).get(position).idInPlayList; // important!
     }
 
     @Override
-    protected void onMultipleItemAction(@NonNull MenuItem menuItem, @NonNull ArrayList<Song> selection) {
+    protected void onMultipleItemAction(@NonNull MenuItem menuItem, @NonNull List<Song> selection) {
         switch (menuItem.getItemId()) {
             case R.id.action_remove_from_playlist:
-                RemoveFromPlaylistDialog.create((ArrayList<PlaylistSong>) (List) selection).show(activity.getSupportFragmentManager(), "ADD_PLAYLIST");
+                RemoveFromPlaylistDialog.create((List<PlaylistSong>) (List) selection).show(activity.getSupportFragmentManager(), "ADD_PLAYLIST");
                 return;
         }
         super.onMultipleItemAction(menuItem, selection);

--- a/app/src/main/java/com/kabouzeid/gramophone/adapter/song/PlayingQueueAdapter.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/adapter/song/PlayingQueueAdapter.java
@@ -18,6 +18,7 @@ import com.kabouzeid.gramophone.model.Song;
 import com.kabouzeid.gramophone.util.ViewUtil;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
@@ -30,7 +31,7 @@ public class PlayingQueueAdapter extends SongAdapter implements DraggableItemAda
 
     private int current;
 
-    public PlayingQueueAdapter(AppCompatActivity activity, ArrayList<Song> dataSet, int current, @LayoutRes int itemLayoutRes, boolean usePalette, @Nullable CabHolder cabHolder) {
+    public PlayingQueueAdapter(AppCompatActivity activity, List<Song> dataSet, int current, @LayoutRes int itemLayoutRes, boolean usePalette, @Nullable CabHolder cabHolder) {
         super(activity, dataSet, itemLayoutRes, usePalette, cabHolder);
         this.current = current;
     }
@@ -66,7 +67,7 @@ public class PlayingQueueAdapter extends SongAdapter implements DraggableItemAda
         // We don't want to load it in this adapter
     }
 
-    public void swapDataSet(ArrayList<Song> dataSet, int position) {
+    public void swapDataSet(List<Song> dataSet, int position) {
         this.dataSet = dataSet;
         current = position;
         notifyDataSetChanged();

--- a/app/src/main/java/com/kabouzeid/gramophone/adapter/song/PlaylistSongAdapter.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/adapter/song/PlaylistSongAdapter.java
@@ -16,13 +16,14 @@ import com.kabouzeid.gramophone.util.MusicUtil;
 import com.kabouzeid.gramophone.util.NavigationUtil;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
  */
 public class PlaylistSongAdapter extends AbsOffsetSongAdapter {
 
-    public PlaylistSongAdapter(AppCompatActivity activity, @NonNull ArrayList<Song> dataSet, @LayoutRes int itemLayoutRes, boolean usePalette, @Nullable CabHolder cabHolder) {
+    public PlaylistSongAdapter(AppCompatActivity activity, @NonNull List<Song> dataSet, @LayoutRes int itemLayoutRes, boolean usePalette, @Nullable CabHolder cabHolder) {
         super(activity, dataSet, itemLayoutRes, usePalette, cabHolder, false);
         setMultiSelectMenuRes(R.menu.menu_cannot_delete_single_songs_playlist_songs_selection);
     }

--- a/app/src/main/java/com/kabouzeid/gramophone/adapter/song/ShuffleButtonSongAdapter.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/adapter/song/ShuffleButtonSongAdapter.java
@@ -14,13 +14,14 @@ import com.kabouzeid.gramophone.interfaces.CabHolder;
 import com.kabouzeid.gramophone.model.Song;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
  */
 public class ShuffleButtonSongAdapter extends AbsOffsetSongAdapter {
 
-    public ShuffleButtonSongAdapter(AppCompatActivity activity, ArrayList<Song> dataSet, @LayoutRes int itemLayoutRes, boolean usePalette, @Nullable CabHolder cabHolder) {
+    public ShuffleButtonSongAdapter(AppCompatActivity activity, List<Song> dataSet, @LayoutRes int itemLayoutRes, boolean usePalette, @Nullable CabHolder cabHolder) {
         super(activity, dataSet, itemLayoutRes, usePalette, cabHolder);
     }
 

--- a/app/src/main/java/com/kabouzeid/gramophone/adapter/song/SongAdapter.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/adapter/song/SongAdapter.java
@@ -61,7 +61,7 @@ public class SongAdapter extends AbsMultiSelectAdapter<SongAdapter.ViewHolder, S
         setHasStableIds(true);
     }
 
-    public void swapDataSet(ArrayList<Song> dataSet) {
+    public void swapDataSet(List<Song> dataSet) {
         this.dataSet = dataSet;
         notifyDataSetChanged();
     }
@@ -178,7 +178,7 @@ public class SongAdapter extends AbsMultiSelectAdapter<SongAdapter.ViewHolder, S
     }
 
     @Override
-    protected void onMultipleItemAction(@NonNull MenuItem menuItem, @NonNull ArrayList<Song> selection) {
+    protected void onMultipleItemAction(@NonNull MenuItem menuItem, @NonNull List<Song> selection) {
         SongsMenuHelper.handleMenuClick(activity, selection, menuItem.getItemId());
     }
 

--- a/app/src/main/java/com/kabouzeid/gramophone/adapter/song/SongAdapter.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/adapter/song/SongAdapter.java
@@ -32,6 +32,7 @@ import com.kabouzeid.gramophone.util.PreferenceUtil;
 import com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
@@ -39,18 +40,18 @@ import java.util.ArrayList;
 public class SongAdapter extends AbsMultiSelectAdapter<SongAdapter.ViewHolder, Song> implements MaterialCab.Callback, FastScrollRecyclerView.SectionedAdapter {
 
     protected final AppCompatActivity activity;
-    protected ArrayList<Song> dataSet;
+    protected List<Song> dataSet;
 
     protected int itemLayoutRes;
 
     protected boolean usePalette = false;
     protected boolean showSectionName = true;
 
-    public SongAdapter(AppCompatActivity activity, ArrayList<Song> dataSet, @LayoutRes int itemLayoutRes, boolean usePalette, @Nullable CabHolder cabHolder) {
+    public SongAdapter(AppCompatActivity activity, List<Song> dataSet, @LayoutRes int itemLayoutRes, boolean usePalette, @Nullable CabHolder cabHolder) {
         this(activity, dataSet, itemLayoutRes, usePalette, cabHolder, true);
     }
 
-    public SongAdapter(AppCompatActivity activity, ArrayList<Song> dataSet, @LayoutRes int itemLayoutRes, boolean usePalette, @Nullable CabHolder cabHolder, boolean showSectionName) {
+    public SongAdapter(AppCompatActivity activity, List<Song> dataSet, @LayoutRes int itemLayoutRes, boolean usePalette, @Nullable CabHolder cabHolder, boolean showSectionName) {
         super(activity, cabHolder, R.menu.menu_media_selection);
         this.activity = activity;
         this.dataSet = dataSet;
@@ -70,7 +71,7 @@ public class SongAdapter extends AbsMultiSelectAdapter<SongAdapter.ViewHolder, S
         notifyDataSetChanged();
     }
 
-    public ArrayList<Song> getDataSet() {
+    public List<Song> getDataSet() {
         return dataSet;
     }
 

--- a/app/src/main/java/com/kabouzeid/gramophone/dialogs/AddToPlaylistDialog.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/dialogs/AddToPlaylistDialog.java
@@ -22,16 +22,16 @@ public class AddToPlaylistDialog extends DialogFragment {
 
     @NonNull
     public static AddToPlaylistDialog create(Song song) {
-        ArrayList<Song> list = new ArrayList<>();
+        List<Song> list = new ArrayList<>();
         list.add(song);
         return create(list);
     }
 
     @NonNull
-    public static AddToPlaylistDialog create(ArrayList<Song> songs) {
+    public static AddToPlaylistDialog create(List<Song> songs) {
         AddToPlaylistDialog dialog = new AddToPlaylistDialog();
         Bundle args = new Bundle();
-        args.putParcelableArrayList("songs", songs);
+        args.putParcelableArrayList("songs", new ArrayList<>(songs));
         dialog.setArguments(args);
         return dialog;
     }
@@ -50,7 +50,7 @@ public class AddToPlaylistDialog extends DialogFragment {
                 .items(playlistNames)
                 .itemsCallback((materialDialog, view, i, charSequence) -> {
                     //noinspection unchecked
-                    final ArrayList<Song> songs = getArguments().getParcelableArrayList("songs");
+                    final List<Song> songs = getArguments().getParcelableArrayList("songs");
                     if (songs == null) return;
                     if (i == 0) {
                         materialDialog.dismiss();

--- a/app/src/main/java/com/kabouzeid/gramophone/dialogs/CreatePlaylistDialog.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/dialogs/CreatePlaylistDialog.java
@@ -14,6 +14,7 @@ import com.kabouzeid.gramophone.model.Song;
 import com.kabouzeid.gramophone.util.PlaylistsUtil;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid), Aidan Follestad (afollestad)
@@ -29,17 +30,17 @@ public class CreatePlaylistDialog extends DialogFragment {
 
     @NonNull
     public static CreatePlaylistDialog create(@Nullable Song song) {
-        ArrayList<Song> list = new ArrayList<>();
+        List<Song> list = new ArrayList<>();
         if (song != null)
             list.add(song);
         return create(list);
     }
 
     @NonNull
-    public static CreatePlaylistDialog create(ArrayList<Song> songs) {
+    public static CreatePlaylistDialog create(List<Song> songs) {
         CreatePlaylistDialog dialog = new CreatePlaylistDialog();
         Bundle args = new Bundle();
-        args.putParcelableArrayList(SONGS, songs);
+        args.putParcelableArrayList(SONGS, new ArrayList<>(songs));
         dialog.setArguments(args);
         return dialog;
     }
@@ -63,7 +64,7 @@ public class CreatePlaylistDialog extends DialogFragment {
                             final int playlistId = PlaylistsUtil.createPlaylist(getActivity(), name);
                             if (getActivity() != null) {
                                 //noinspection unchecked
-                                ArrayList<Song> songs = getArguments().getParcelableArrayList(SONGS);
+                                List<Song> songs = getArguments().getParcelableArrayList(SONGS);
                                 if (songs != null && !songs.isEmpty()) {
                                     PlaylistsUtil.addToPlaylist(getActivity(), songs, playlistId, true);
                                 }

--- a/app/src/main/java/com/kabouzeid/gramophone/dialogs/DeletePlaylistDialog.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/dialogs/DeletePlaylistDialog.java
@@ -12,6 +12,7 @@ import com.kabouzeid.gramophone.model.Playlist;
 import com.kabouzeid.gramophone.util.PlaylistsUtil;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
@@ -20,16 +21,16 @@ public class DeletePlaylistDialog extends DialogFragment {
 
     @NonNull
     public static DeletePlaylistDialog create(Playlist playlist) {
-        ArrayList<Playlist> list = new ArrayList<>();
+        List<Playlist> list = new ArrayList<>();
         list.add(playlist);
         return create(list);
     }
 
     @NonNull
-    public static DeletePlaylistDialog create(ArrayList<Playlist> playlists) {
+    public static DeletePlaylistDialog create(List<Playlist> playlists) {
         DeletePlaylistDialog dialog = new DeletePlaylistDialog();
         Bundle args = new Bundle();
-        args.putParcelableArrayList("playlists", playlists);
+        args.putParcelableArrayList("playlists", new ArrayList<>(playlists));
         dialog.setArguments(args);
         return dialog;
     }
@@ -38,7 +39,7 @@ public class DeletePlaylistDialog extends DialogFragment {
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         //noinspection unchecked
-        final ArrayList<Playlist> playlists = getArguments().getParcelableArrayList("playlists");
+        final List<Playlist> playlists = getArguments().getParcelableArrayList("playlists");
         int title;
         CharSequence content;
         //noinspection ConstantConditions

--- a/app/src/main/java/com/kabouzeid/gramophone/dialogs/DeleteSongsDialog.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/dialogs/DeleteSongsDialog.java
@@ -12,6 +12,7 @@ import com.kabouzeid.gramophone.model.Song;
 import com.kabouzeid.gramophone.util.MusicUtil;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid), Aidan Follestad (afollestad)
@@ -20,16 +21,16 @@ public class DeleteSongsDialog extends DialogFragment {
 
     @NonNull
     public static DeleteSongsDialog create(Song song) {
-        ArrayList<Song> list = new ArrayList<>();
+        List<Song> list = new ArrayList<>();
         list.add(song);
         return create(list);
     }
 
     @NonNull
-    public static DeleteSongsDialog create(ArrayList<Song> songs) {
+    public static DeleteSongsDialog create(List<Song> songs) {
         DeleteSongsDialog dialog = new DeleteSongsDialog();
         Bundle args = new Bundle();
-        args.putParcelableArrayList("songs", songs);
+        args.putParcelableArrayList("songs", new ArrayList<>(songs));
         dialog.setArguments(args);
         return dialog;
     }
@@ -38,7 +39,7 @@ public class DeleteSongsDialog extends DialogFragment {
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         //noinspection unchecked
-        final ArrayList<Song> songs = getArguments().getParcelableArrayList("songs");
+        final List<Song> songs = getArguments().getParcelableArrayList("songs");
         int title;
         CharSequence content;
         if (songs.size() > 1) {

--- a/app/src/main/java/com/kabouzeid/gramophone/dialogs/RemoveFromPlaylistDialog.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/dialogs/RemoveFromPlaylistDialog.java
@@ -12,6 +12,7 @@ import com.kabouzeid.gramophone.model.PlaylistSong;
 import com.kabouzeid.gramophone.util.PlaylistsUtil;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
@@ -20,16 +21,16 @@ public class RemoveFromPlaylistDialog extends DialogFragment {
 
     @NonNull
     public static RemoveFromPlaylistDialog create(PlaylistSong song) {
-        ArrayList<PlaylistSong> list = new ArrayList<>();
+        List<PlaylistSong> list = new ArrayList<>();
         list.add(song);
         return create(list);
     }
 
     @NonNull
-    public static RemoveFromPlaylistDialog create(ArrayList<PlaylistSong> songs) {
+    public static RemoveFromPlaylistDialog create(List<PlaylistSong> songs) {
         RemoveFromPlaylistDialog dialog = new RemoveFromPlaylistDialog();
         Bundle args = new Bundle();
-        args.putParcelableArrayList("songs", songs);
+        args.putParcelableArrayList("songs", new ArrayList<>(songs));
         dialog.setArguments(args);
         return dialog;
     }
@@ -38,7 +39,7 @@ public class RemoveFromPlaylistDialog extends DialogFragment {
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         //noinspection unchecked
-        final ArrayList<PlaylistSong> songs = getArguments().getParcelableArrayList("songs");
+        final List<PlaylistSong> songs = getArguments().getParcelableArrayList("songs");
         int title;
         CharSequence content;
         if (songs.size() > 1) {

--- a/app/src/main/java/com/kabouzeid/gramophone/dialogs/ScanMediaFolderChooserDialog.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/dialogs/ScanMediaFolderChooserDialog.java
@@ -116,7 +116,7 @@ public class ScanMediaFolderChooserDialog extends DialogFragment implements Mate
                             final Context applicationContext = getActivity().getApplicationContext();
                             final WeakReference<Activity> activityWeakReference = new WeakReference<>(getActivity());
                             dismiss();
-                            new FoldersFragment.ListPathsAsyncTask(getActivity(), paths -> scanPaths(activityWeakReference, applicationContext, paths)).execute(new FoldersFragment.ListPathsAsyncTask.LoadingInfo(parentFolder, FoldersFragment.AUDIO_FILE_FILTER));
+                            new FoldersFragment.ArrayListPathsAsyncTask(getActivity(), paths -> scanPaths(activityWeakReference, applicationContext, paths)).execute(new FoldersFragment.ArrayListPathsAsyncTask.LoadingInfo(parentFolder, FoldersFragment.AUDIO_FILE_FILTER));
                         })
                         .onNegative((materialDialog, dialogAction) -> dismiss())
                         .positiveText(R.string.action_scan_directory)

--- a/app/src/main/java/com/kabouzeid/gramophone/helper/M3UWriter.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/helper/M3UWriter.java
@@ -12,6 +12,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 
 public class M3UWriter implements M3UConstants {
 
@@ -20,7 +21,7 @@ public class M3UWriter implements M3UConstants {
             dir.mkdirs();
         File file = new File(dir, playlist.name.concat("." + EXTENSION));
 
-        ArrayList<? extends Song> songs;
+        List<? extends Song> songs;
         if (playlist instanceof AbsCustomPlaylist) {
             songs = ((AbsCustomPlaylist) playlist).getSongs(context);
         } else {

--- a/app/src/main/java/com/kabouzeid/gramophone/helper/MusicPlayerRemote.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/helper/MusicPlayerRemote.java
@@ -28,6 +28,7 @@ import com.kabouzeid.gramophone.util.PreferenceUtil;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 import java.util.WeakHashMap;
 
@@ -174,7 +175,7 @@ public class MusicPlayerRemote {
     /**
      * Async
      */
-    public static void openQueue(final ArrayList<Song> queue, final int startPosition, final boolean startPlaying) {
+    public static void openQueue(final List<Song> queue, final int startPosition, final boolean startPlaying) {
         if (!tryToHandleOpenPlayingQueue(queue, startPosition, startPlaying) && musicService != null) {
             musicService.openQueue(queue, startPosition, startPlaying);
             if (!PreferenceUtil.getInstance(musicService).rememberShuffle()){
@@ -186,7 +187,7 @@ public class MusicPlayerRemote {
     /**
      * Async
      */
-    public static void openAndShuffleQueue(final ArrayList<Song> queue, boolean startPlaying) {
+    public static void openAndShuffleQueue(final List<Song> queue, boolean startPlaying) {
         int startPosition = 0;
         if (!queue.isEmpty()) {
             startPosition = new Random().nextInt(queue.size());
@@ -198,7 +199,7 @@ public class MusicPlayerRemote {
         }
     }
 
-    private static boolean tryToHandleOpenPlayingQueue(final ArrayList<Song> queue, final int startPosition, final boolean startPlaying) {
+    private static boolean tryToHandleOpenPlayingQueue(final List<Song> queue, final int startPosition, final boolean startPlaying) {
         if (getPlayingQueue() == queue) {
             if (startPlaying) {
                 playSongAt(startPosition);
@@ -224,7 +225,7 @@ public class MusicPlayerRemote {
         return -1;
     }
 
-    public static ArrayList<Song> getPlayingQueue() {
+    public static List<Song> getPlayingQueue() {
         if (musicService != null) {
             return musicService.getPlayingQueue();
         }
@@ -302,7 +303,7 @@ public class MusicPlayerRemote {
             if (getPlayingQueue().size() > 0) {
                 musicService.addSong(getPosition() + 1, song);
             } else {
-                ArrayList<Song> queue = new ArrayList<>();
+                List<Song> queue = new ArrayList<>();
                 queue.add(song);
                 openQueue(queue, 0, false);
             }
@@ -312,7 +313,7 @@ public class MusicPlayerRemote {
         return false;
     }
 
-    public static boolean playNext(@NonNull ArrayList<Song> songs) {
+    public static boolean playNext(@NonNull List<Song> songs) {
         if (musicService != null) {
             if (getPlayingQueue().size() > 0) {
                 musicService.addSongs(getPosition() + 1, songs);
@@ -331,7 +332,7 @@ public class MusicPlayerRemote {
             if (getPlayingQueue().size() > 0) {
                 musicService.addSong(song);
             } else {
-                ArrayList<Song> queue = new ArrayList<>();
+                List<Song> queue = new ArrayList<>();
                 queue.add(song);
                 openQueue(queue, 0, false);
             }
@@ -341,7 +342,7 @@ public class MusicPlayerRemote {
         return false;
     }
 
-    public static boolean enqueue(@NonNull ArrayList<Song> songs) {
+    public static boolean enqueue(@NonNull List<Song> songs) {
         if (musicService != null) {
             if (getPlayingQueue().size() > 0) {
                 musicService.addSongs(songs);
@@ -396,7 +397,7 @@ public class MusicPlayerRemote {
 
     public static void playFromUri(Uri uri) {
         if (musicService != null) {
-            ArrayList<Song> songs = null;
+            List<Song> songs = null;
             if (uri.getScheme() != null && uri.getAuthority() != null) {
                 if (uri.getScheme().equals(ContentResolver.SCHEME_CONTENT)) {
                     String songId = null;

--- a/app/src/main/java/com/kabouzeid/gramophone/helper/SearchQueryHelper.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/helper/SearchQueryHelper.java
@@ -10,6 +10,7 @@ import com.kabouzeid.gramophone.loader.SongLoader;
 import com.kabouzeid.gramophone.model.Song;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
@@ -21,13 +22,13 @@ public class SearchQueryHelper {
     private static final String AND = " AND ";
 
     @NonNull
-    public static ArrayList<Song> getSongs(@NonNull final Context context, @NonNull final Bundle extras) {
+    public static List<Song> getSongs(@NonNull final Context context, @NonNull final Bundle extras) {
         final String query = extras.getString(SearchManager.QUERY, null);
         final String artistName = extras.getString(MediaStore.EXTRA_MEDIA_ARTIST, null);
         final String albumName = extras.getString(MediaStore.EXTRA_MEDIA_ALBUM, null);
         final String titleName = extras.getString(MediaStore.EXTRA_MEDIA_TITLE, null);
 
-        ArrayList<Song> songs = new ArrayList<>();
+        List<Song> songs = new ArrayList<>();
 
         if (artistName != null && albumName != null && titleName != null) {
             songs = SongLoader.getSongs(SongLoader.makeSongCursor(context, ARTIST_SELECTION + AND + ALBUM_SELECTION + AND + TITLE_SELECTION, new String[]{artistName.toLowerCase().trim(), albumName.toLowerCase().trim(), titleName.toLowerCase().trim()}));

--- a/app/src/main/java/com/kabouzeid/gramophone/helper/StackBlur.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/helper/StackBlur.java
@@ -3,6 +3,7 @@ package com.kabouzeid.gramophone.helper;
 import android.graphics.Bitmap;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -83,8 +84,8 @@ public class StackBlur {
         original.getPixels(currentPixels, 0, w, 0, 0, w, h);
         int cores = EXECUTOR_THREADS;
 
-        ArrayList<BlurTask> horizontal = new ArrayList<>(cores);
-        ArrayList<BlurTask> vertical = new ArrayList<>(cores);
+        List<BlurTask> horizontal = new ArrayList<>(cores);
+        List<BlurTask> vertical = new ArrayList<>(cores);
         for (int i = 0; i < cores; i++) {
             horizontal.add(new BlurTask(currentPixels, w, h, (int) radius, cores, i, 1));
             vertical.add(new BlurTask(currentPixels, w, h, (int) radius, cores, i, 2));

--- a/app/src/main/java/com/kabouzeid/gramophone/helper/menu/PlaylistMenuHelper.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/helper/menu/PlaylistMenuHelper.java
@@ -22,6 +22,7 @@ import com.kabouzeid.gramophone.util.PlaylistsUtil;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
@@ -55,7 +56,7 @@ public class PlaylistMenuHelper {
     }
 
     @NonNull
-    private static ArrayList<? extends Song> getPlaylistSongs(@NonNull Activity activity, Playlist playlist) {
+    private static List<? extends Song> getPlaylistSongs(@NonNull Activity activity, Playlist playlist) {
         return playlist instanceof AbsCustomPlaylist ?
                 ((AbsCustomPlaylist) playlist).getSongs(activity) :
                 PlaylistSongLoader.getPlaylistSongList(activity, playlist.id);

--- a/app/src/main/java/com/kabouzeid/gramophone/helper/menu/SongsMenuHelper.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/helper/menu/SongsMenuHelper.java
@@ -10,12 +10,13 @@ import com.kabouzeid.gramophone.helper.MusicPlayerRemote;
 import com.kabouzeid.gramophone.model.Song;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
  */
 public class SongsMenuHelper {
-    public static boolean handleMenuClick(@NonNull FragmentActivity activity, @NonNull ArrayList<Song> songs, int menuItemId) {
+    public static boolean handleMenuClick(@NonNull FragmentActivity activity, @NonNull List<Song> songs, int menuItemId) {
         switch (menuItemId) {
             case R.id.action_play_next:
                 MusicPlayerRemote.playNext(songs);

--- a/app/src/main/java/com/kabouzeid/gramophone/loader/AlbumLoader.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/loader/AlbumLoader.java
@@ -11,6 +11,7 @@ import com.kabouzeid.gramophone.util.PreferenceUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
@@ -22,8 +23,8 @@ public class AlbumLoader {
     }
 
     @NonNull
-    public static ArrayList<Album> getAllAlbums(@NonNull final Context context) {
-        ArrayList<Song> songs = SongLoader.getSongs(SongLoader.makeSongCursor(
+    public static List<Album> getAllAlbums(@NonNull final Context context) {
+        List<Song> songs = SongLoader.getSongs(SongLoader.makeSongCursor(
                 context,
                 null,
                 null,
@@ -33,8 +34,8 @@ public class AlbumLoader {
     }
 
     @NonNull
-    public static ArrayList<Album> getAlbums(@NonNull final Context context, String query) {
-        ArrayList<Song> songs = SongLoader.getSongs(SongLoader.makeSongCursor(
+    public static List<Album> getAlbums(@NonNull final Context context, String query) {
+        List<Song> songs = SongLoader.getSongs(SongLoader.makeSongCursor(
                 context,
                 AudioColumns.ALBUM + " LIKE ?",
                 new String[]{"%" + query + "%"},
@@ -45,15 +46,15 @@ public class AlbumLoader {
 
     @NonNull
     public static Album getAlbum(@NonNull final Context context, int albumId) {
-        ArrayList<Song> songs = SongLoader.getSongs(SongLoader.makeSongCursor(context, AudioColumns.ALBUM_ID + "=?", new String[]{String.valueOf(albumId)}, getSongLoaderSortOrder(context)));
+        List<Song> songs = SongLoader.getSongs(SongLoader.makeSongCursor(context, AudioColumns.ALBUM_ID + "=?", new String[]{String.valueOf(albumId)}, getSongLoaderSortOrder(context)));
         Album album = new Album(songs);
         sortSongsByTrackNumber(album);
         return album;
     }
 
     @NonNull
-    public static ArrayList<Album> splitIntoAlbums(@Nullable final ArrayList<Song> songs) {
-        ArrayList<Album> albums = new ArrayList<>();
+    public static List<Album> splitIntoAlbums(@Nullable final List<Song> songs) {
+        List<Album> albums = new ArrayList<>();
         if (songs != null) {
             for (Song song : songs) {
                 getOrCreateAlbum(albums, song.albumId).songs.add(song);
@@ -65,7 +66,7 @@ public class AlbumLoader {
         return albums;
     }
 
-    private static Album getOrCreateAlbum(ArrayList<Album> albums, int albumId) {
+    private static Album getOrCreateAlbum(List<Album> albums, int albumId) {
         for (Album album : albums) {
             if (!album.songs.isEmpty() && album.songs.get(0).albumId == albumId) {
                 return album;

--- a/app/src/main/java/com/kabouzeid/gramophone/loader/ArtistLoader.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/loader/ArtistLoader.java
@@ -11,6 +11,7 @@ import com.kabouzeid.gramophone.model.Song;
 import com.kabouzeid.gramophone.util.PreferenceUtil;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
@@ -21,8 +22,8 @@ public class ArtistLoader {
     }
 
     @NonNull
-    public static ArrayList<Artist> getAllArtists(@NonNull final Context context) {
-        ArrayList<Song> songs = SongLoader.getSongs(SongLoader.makeSongCursor(
+    public static List<Artist> getAllArtists(@NonNull final Context context) {
+        List<Song> songs = SongLoader.getSongs(SongLoader.makeSongCursor(
                 context,
                 null,
                 null,
@@ -32,8 +33,8 @@ public class ArtistLoader {
     }
 
     @NonNull
-    public static ArrayList<Artist> getArtists(@NonNull final Context context, String query) {
-        ArrayList<Song> songs = SongLoader.getSongs(SongLoader.makeSongCursor(
+    public static List<Artist> getArtists(@NonNull final Context context, String query) {
+        List<Song> songs = SongLoader.getSongs(SongLoader.makeSongCursor(
                 context,
                 AudioColumns.ARTIST + " LIKE ?",
                 new String[]{"%" + query + "%"},
@@ -44,7 +45,7 @@ public class ArtistLoader {
 
     @NonNull
     public static Artist getArtist(@NonNull final Context context, int artistId) {
-        ArrayList<Song> songs = SongLoader.getSongs(SongLoader.makeSongCursor(
+        List<Song> songs = SongLoader.getSongs(SongLoader.makeSongCursor(
                 context,
                 AudioColumns.ARTIST_ID + "=?",
                 new String[]{String.valueOf(artistId)},
@@ -54,8 +55,8 @@ public class ArtistLoader {
     }
 
     @NonNull
-    public static ArrayList<Artist> splitIntoArtists(@Nullable final ArrayList<Album> albums) {
-        ArrayList<Artist> artists = new ArrayList<>();
+    public static List<Artist> splitIntoArtists(@Nullable final List<Album> albums) {
+        List<Artist> artists = new ArrayList<>();
         if (albums != null) {
             for (Album album : albums) {
                 getOrCreateArtist(artists, album.getArtistId()).albums.add(album);
@@ -64,7 +65,7 @@ public class ArtistLoader {
         return artists;
     }
 
-    private static Artist getOrCreateArtist(ArrayList<Artist> artists, int artistId) {
+    private static Artist getOrCreateArtist(List<Artist> artists, int artistId) {
         for (Artist artist : artists) {
             if (!artist.albums.isEmpty() && !artist.albums.get(0).songs.isEmpty() && artist.albums.get(0).songs.get(0).artistId == artistId) {
                 return artist;

--- a/app/src/main/java/com/kabouzeid/gramophone/loader/GenreLoader.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/loader/GenreLoader.java
@@ -11,22 +11,23 @@ import com.kabouzeid.gramophone.model.Song;
 import com.kabouzeid.gramophone.util.PreferenceUtil;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class GenreLoader {
 
     @NonNull
-    public static ArrayList<Genre> getAllGenres(@NonNull final Context context) {
+    public static List<Genre> getAllGenres(@NonNull final Context context) {
         return getGenresFromCursor(context, makeGenreCursor(context));
     }
 
     @NonNull
-    public static ArrayList<Song> getSongs(@NonNull final Context context, final int genreId) {
+    public static List<Song> getSongs(@NonNull final Context context, final int genreId) {
         return SongLoader.getSongs(makeGenreSongCursor(context, genreId));
     }
 
     @NonNull
-    private static ArrayList<Genre> getGenresFromCursor(@NonNull final Context context, @Nullable final Cursor cursor) {
-        final ArrayList<Genre> genres = new ArrayList<>();
+    private static List<Genre> getGenresFromCursor(@NonNull final Context context, @Nullable final Cursor cursor) {
+        final List<Genre> genres = new ArrayList<>();
         if (cursor != null) {
             if (cursor.moveToFirst()) {
                 do {

--- a/app/src/main/java/com/kabouzeid/gramophone/loader/LastAddedLoader.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/loader/LastAddedLoader.java
@@ -9,11 +9,12 @@ import com.kabouzeid.gramophone.model.Song;
 import com.kabouzeid.gramophone.util.PreferenceUtil;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class LastAddedLoader {
 
     @NonNull
-    public static ArrayList<Song> getLastAddedSongs(@NonNull Context context) {
+    public static List<Song> getLastAddedSongs(@NonNull Context context) {
         return SongLoader.getSongs(makeLastAddedCursor(context));
     }
 

--- a/app/src/main/java/com/kabouzeid/gramophone/loader/PlaylistLoader.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/loader/PlaylistLoader.java
@@ -11,11 +11,12 @@ import androidx.annotation.Nullable;
 import com.kabouzeid.gramophone.model.Playlist;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class PlaylistLoader {
 
     @NonNull
-    public static ArrayList<Playlist> getAllPlaylists(@NonNull final Context context) {
+    public static List<Playlist> getAllPlaylists(@NonNull final Context context) {
         return getAllPlaylists(makePlaylistCursor(context, null, null));
     }
 
@@ -54,8 +55,8 @@ public class PlaylistLoader {
     }
 
     @NonNull
-    public static ArrayList<Playlist> getAllPlaylists(@Nullable final Cursor cursor) {
-        ArrayList<Playlist> playlists = new ArrayList<>();
+    public static List<Playlist> getAllPlaylists(@Nullable final Cursor cursor) {
+        List<Playlist> playlists = new ArrayList<>();
 
         if (cursor != null && cursor.moveToFirst()) {
             do {

--- a/app/src/main/java/com/kabouzeid/gramophone/loader/PlaylistSongLoader.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/loader/PlaylistSongLoader.java
@@ -9,12 +9,13 @@ import androidx.annotation.NonNull;
 import com.kabouzeid.gramophone.model.PlaylistSong;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class PlaylistSongLoader {
 
     @NonNull
-    public static ArrayList<PlaylistSong> getPlaylistSongList(@NonNull final Context context, final int playlistId) {
-        ArrayList<PlaylistSong> songs = new ArrayList<>();
+    public static List<PlaylistSong> getPlaylistSongList(@NonNull final Context context, final int playlistId) {
+        List<PlaylistSong> songs = new ArrayList<>();
         Cursor cursor = makePlaylistSongCursor(context, playlistId);
 
         if (cursor != null && cursor.moveToFirst()) {

--- a/app/src/main/java/com/kabouzeid/gramophone/loader/SongLoader.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/loader/SongLoader.java
@@ -13,6 +13,7 @@ import com.kabouzeid.gramophone.provider.BlacklistStore;
 import com.kabouzeid.gramophone.util.PreferenceUtil;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
@@ -34,13 +35,13 @@ public class SongLoader {
     };
 
     @NonNull
-    public static ArrayList<Song> getAllSongs(@NonNull Context context) {
+    public static List<Song> getAllSongs(@NonNull Context context) {
         Cursor cursor = makeSongCursor(context, null, null);
         return getSongs(cursor);
     }
 
     @NonNull
-    public static ArrayList<Song> getSongs(@NonNull final Context context, final String query) {
+    public static List<Song> getSongs(@NonNull final Context context, final String query) {
         Cursor cursor = makeSongCursor(context, AudioColumns.TITLE + " LIKE ?", new String[]{"%" + query + "%"});
         return getSongs(cursor);
     }
@@ -52,8 +53,8 @@ public class SongLoader {
     }
 
     @NonNull
-    public static ArrayList<Song> getSongs(@Nullable final Cursor cursor) {
-        ArrayList<Song> songs = new ArrayList<>();
+    public static List<Song> getSongs(@Nullable final Cursor cursor) {
+        List<Song> songs = new ArrayList<>();
         if (cursor != null && cursor.moveToFirst()) {
             do {
                 songs.add(getSongFromCursorImpl(cursor));
@@ -110,7 +111,7 @@ public class SongLoader {
         }
 
         // Blacklist
-        ArrayList<String> paths = BlacklistStore.getInstance(context).getPaths();
+        List<String> paths = BlacklistStore.getInstance(context).getPaths();
         if (!paths.isEmpty()) {
             selection = generateBlacklistSelection(selection, paths.size());
             selectionValues = addBlacklistSelectionValues(selectionValues, paths);
@@ -133,7 +134,7 @@ public class SongLoader {
         return newSelection;
     }
 
-    private static String[] addBlacklistSelectionValues(String[] selectionValues, ArrayList<String> paths) {
+    private static String[] addBlacklistSelectionValues(String[] selectionValues, List<String> paths) {
         if (selectionValues == null) selectionValues = new String[0];
         String[] newSelectionValues = new String[selectionValues.length + paths.size()];
         System.arraycopy(selectionValues, 0, newSelectionValues, 0, selectionValues.length);

--- a/app/src/main/java/com/kabouzeid/gramophone/loader/SortedCursor.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/loader/SortedCursor.java
@@ -23,6 +23,7 @@ import androidx.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * This cursor basically wraps a song cursor and is given a list of the order of the ids of the
@@ -33,9 +34,9 @@ public class SortedCursor extends AbstractCursor {
     // cursor to wrap
     private final Cursor mCursor;
     // the map of external indices to internal indices
-    private ArrayList<Integer> mOrderedPositions;
+    private List<Integer> mOrderedPositions;
     // this contains the ids that weren't found in the underlying cursor
-    private ArrayList<String> mMissingValues;
+    private List<String> mMissingValues;
     // this contains the mapped cursor positions and afterwards the extra ids that weren't found
     private HashMap<String, Integer> mMapCursorPositions;
 
@@ -57,8 +58,8 @@ public class SortedCursor extends AbstractCursor {
      * @return returns the ids that aren't found in the underlying cursor
      */
     @NonNull
-    private ArrayList<String> buildCursorPositionMapping(@Nullable final String[] order, final String columnName) {
-        ArrayList<String> missingValues = new ArrayList<>();
+    private List<String> buildCursorPositionMapping(@Nullable final String[] order, final String columnName) {
+        List<String> missingValues = new ArrayList<>();
 
         mOrderedPositions = new ArrayList<>(mCursor.getCount());
 
@@ -93,7 +94,7 @@ public class SortedCursor extends AbstractCursor {
     /**
      * @return the list of ids that weren't found in the underlying cursor
      */
-    public ArrayList<String> getMissingValues() {
+    public List<String> getMissingValues() {
         return mMissingValues;
     }
 

--- a/app/src/main/java/com/kabouzeid/gramophone/loader/SortedLongCursor.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/loader/SortedLongCursor.java
@@ -23,6 +23,7 @@ import androidx.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * This cursor basically wraps a song cursor and is given a list of the order of the ids of the
@@ -33,9 +34,9 @@ public class SortedLongCursor extends AbstractCursor {
     // cursor to wrap
     private final Cursor mCursor;
     // the map of external indices to internal indices
-    private ArrayList<Integer> mOrderedPositions;
+    private List<Integer> mOrderedPositions;
     // this contains the ids that weren't found in the underlying cursor
-    private ArrayList<Long> mMissingIds;
+    private List<Long> mMissingIds;
     // this contains the mapped cursor positions and afterwards the extra ids that weren't found
     private HashMap<Long, Integer> mMapCursorPositions;
 
@@ -58,8 +59,8 @@ public class SortedLongCursor extends AbstractCursor {
      * @return returns the ids that aren't found in the underlying cursor
      */
     @NonNull
-    private ArrayList<Long> buildCursorPositionMapping(@Nullable final long[] order, final String columnName) {
-        ArrayList<Long> missingIds = new ArrayList<>();
+    private List<Long> buildCursorPositionMapping(@Nullable final long[] order, final String columnName) {
+        List<Long> missingIds = new ArrayList<>();
 
         mOrderedPositions = new ArrayList<>(mCursor.getCount());
 
@@ -93,7 +94,7 @@ public class SortedLongCursor extends AbstractCursor {
     /**
      * @return the list of ids that weren't found in the underlying cursor
      */
-    public ArrayList<Long> getMissingIds() {
+    public List<Long> getMissingIds() {
         return mMissingIds;
     }
 

--- a/app/src/main/java/com/kabouzeid/gramophone/loader/TopAndRecentlyPlayedTracksLoader.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/loader/TopAndRecentlyPlayedTracksLoader.java
@@ -28,17 +28,18 @@ import com.kabouzeid.gramophone.provider.HistoryStore;
 import com.kabouzeid.gramophone.provider.SongPlayCountStore;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class TopAndRecentlyPlayedTracksLoader {
     public static final int NUMBER_OF_TOP_TRACKS = 100;
 
     @NonNull
-    public static ArrayList<Song> getRecentlyPlayedTracks(@NonNull Context context) {
+    public static List<Song> getRecentlyPlayedTracks(@NonNull Context context) {
         return SongLoader.getSongs(makeRecentTracksCursorAndClearUpDatabase(context));
     }
 
     @NonNull
-    public static ArrayList<Song> getTopTracks(@NonNull Context context) {
+    public static List<Song> getTopTracks(@NonNull Context context) {
         return SongLoader.getSongs(makeTopTracksCursorAndClearUpDatabase(context));
     }
 
@@ -48,7 +49,7 @@ public class TopAndRecentlyPlayedTracksLoader {
 
         // clean up the databases with any ids not found
         if (retCursor != null) {
-            ArrayList<Long> missingIds = retCursor.getMissingIds();
+            List<Long> missingIds = retCursor.getMissingIds();
             if (missingIds != null && missingIds.size() > 0) {
                 for (long id : missingIds) {
                     HistoryStore.getInstance(context).removeSongId(id);
@@ -64,7 +65,7 @@ public class TopAndRecentlyPlayedTracksLoader {
 
         // clean up the databases with any ids not found
         if (retCursor != null) {
-            ArrayList<Long> missingIds = retCursor.getMissingIds();
+            List<Long> missingIds = retCursor.getMissingIds();
             if (missingIds != null && missingIds.size() > 0) {
                 for (long id : missingIds) {
                     SongPlayCountStore.getInstance(context).removeItem(id);

--- a/app/src/main/java/com/kabouzeid/gramophone/misc/CustomFragmentStatePagerAdapter.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/misc/CustomFragmentStatePagerAdapter.java
@@ -29,6 +29,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Implementation of {@link PagerAdapter} that
@@ -74,8 +75,8 @@ public abstract class CustomFragmentStatePagerAdapter extends PagerAdapter {
     private final FragmentManager mFragmentManager;
     private FragmentTransaction mCurTransaction = null;
 
-    private ArrayList<Fragment.SavedState> mSavedState = new ArrayList<>();
-    private ArrayList<Fragment> mFragments = new ArrayList<>();
+    private List<Fragment.SavedState> mSavedState = new ArrayList<>();
+    private List<Fragment> mFragments = new ArrayList<>();
     private Fragment mCurrentPrimaryItem = null;
 
     public CustomFragmentStatePagerAdapter(FragmentManager fm) {

--- a/app/src/main/java/com/kabouzeid/gramophone/model/AbsCustomPlaylist.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/model/AbsCustomPlaylist.java
@@ -5,6 +5,7 @@ import android.os.Parcel;
 import androidx.annotation.NonNull;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
@@ -23,5 +24,5 @@ public abstract class AbsCustomPlaylist extends Playlist {
     }
 
     @NonNull
-    public abstract ArrayList<Song> getSongs(Context context);
+    public abstract List<Song> getSongs(Context context);
 }

--- a/app/src/main/java/com/kabouzeid/gramophone/model/Album.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/model/Album.java
@@ -5,14 +5,15 @@ import android.os.Parcelable;
 import androidx.annotation.NonNull;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
  */
 public class Album implements Parcelable {
-    public final ArrayList<Song> songs;
+    public final List<Song> songs;
 
-    public Album(ArrayList<Song> songs) {
+    public Album(List<Song> songs) {
         this.songs = songs;
     }
 

--- a/app/src/main/java/com/kabouzeid/gramophone/model/Artist.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/model/Artist.java
@@ -7,6 +7,7 @@ import androidx.annotation.NonNull;
 import com.kabouzeid.gramophone.util.MusicUtil;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
@@ -14,9 +15,9 @@ import java.util.ArrayList;
 public class Artist implements Parcelable {
     public static final String UNKNOWN_ARTIST_DISPLAY_NAME = "Unknown Artist";
 
-    public final ArrayList<Album> albums;
+    public final List<Album> albums;
 
-    public Artist(ArrayList<Album> albums) {
+    public Artist(List<Album> albums) {
         this.albums = albums;
     }
 
@@ -48,8 +49,8 @@ public class Artist implements Parcelable {
         return albums.size();
     }
 
-    public ArrayList<Song> getSongs() {
-        ArrayList<Song> songs = new ArrayList<>();
+    public List<Song> getSongs() {
+        List<Song> songs = new ArrayList<>();
         for (Album album : albums) {
             songs.addAll(album.songs);
         }

--- a/app/src/main/java/com/kabouzeid/gramophone/model/lyrics/Lyrics.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/model/lyrics/Lyrics.java
@@ -3,9 +3,10 @@ package com.kabouzeid.gramophone.model.lyrics;
 import com.kabouzeid.gramophone.model.Song;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class Lyrics {
-    private static final ArrayList<Class<? extends Lyrics>> FORMATS = new ArrayList<>();
+    private static final List<Class<? extends Lyrics>> FORMATS = new ArrayList<>();
 
     public Song song;
     public String data;

--- a/app/src/main/java/com/kabouzeid/gramophone/model/smartplaylist/HistoryPlaylist.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/model/smartplaylist/HistoryPlaylist.java
@@ -11,6 +11,7 @@ import com.kabouzeid.gramophone.R;
 import com.kabouzeid.gramophone.util.PreferenceUtil;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
@@ -23,7 +24,7 @@ public class HistoryPlaylist extends AbsSmartPlaylist {
 
     @NonNull
     @Override
-    public ArrayList<Song> getSongs(@NonNull Context context) {
+    public List<Song> getSongs(@NonNull Context context) {
         return TopAndRecentlyPlayedTracksLoader.getRecentlyPlayedTracks(context);
     }
 

--- a/app/src/main/java/com/kabouzeid/gramophone/model/smartplaylist/LastAddedPlaylist.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/model/smartplaylist/LastAddedPlaylist.java
@@ -10,6 +10,7 @@ import com.kabouzeid.gramophone.R;
 import com.kabouzeid.gramophone.util.PreferenceUtil;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
@@ -22,7 +23,7 @@ public class LastAddedPlaylist extends AbsSmartPlaylist {
 
     @NonNull
     @Override
-    public ArrayList<Song> getSongs(@NonNull Context context) {
+    public List<Song> getSongs(@NonNull Context context) {
         return LastAddedLoader.getLastAddedSongs(context);
     }
 

--- a/app/src/main/java/com/kabouzeid/gramophone/model/smartplaylist/MyTopTracksPlaylist.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/model/smartplaylist/MyTopTracksPlaylist.java
@@ -10,6 +10,7 @@ import com.kabouzeid.gramophone.model.Song;
 import com.kabouzeid.gramophone.provider.SongPlayCountStore;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
@@ -22,7 +23,7 @@ public class MyTopTracksPlaylist extends AbsSmartPlaylist {
 
     @NonNull
     @Override
-    public ArrayList<Song> getSongs(@NonNull Context context) {
+    public List<Song> getSongs(@NonNull Context context) {
         return TopAndRecentlyPlayedTracksLoader.getTopTracks(context);
     }
 

--- a/app/src/main/java/com/kabouzeid/gramophone/model/smartplaylist/ShuffleAllPlaylist.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/model/smartplaylist/ShuffleAllPlaylist.java
@@ -9,6 +9,7 @@ import com.kabouzeid.gramophone.loader.SongLoader;
 import com.kabouzeid.gramophone.model.Song;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class ShuffleAllPlaylist extends AbsSmartPlaylist {
 
@@ -18,7 +19,7 @@ public class ShuffleAllPlaylist extends AbsSmartPlaylist {
 
     @NonNull
     @Override
-    public ArrayList<Song> getSongs(@NonNull Context context) {
+    public List<Song> getSongs(@NonNull Context context) {
         return SongLoader.getAllSongs(context);
     }
 

--- a/app/src/main/java/com/kabouzeid/gramophone/preferences/BlacklistPreferenceDialog.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/preferences/BlacklistPreferenceDialog.java
@@ -13,13 +13,14 @@ import com.kabouzeid.gramophone.provider.BlacklistStore;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
  */
 public class BlacklistPreferenceDialog extends DialogFragment implements BlacklistFolderChooserDialog.FolderCallback {
 
-    private ArrayList<String> paths;
+    private List<String> paths;
 
     public static BlacklistPreferenceDialog newInstance() {
         return new BlacklistPreferenceDialog();

--- a/app/src/main/java/com/kabouzeid/gramophone/preferences/LibraryPreferenceDialog.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/preferences/LibraryPreferenceDialog.java
@@ -15,6 +15,7 @@ import com.kabouzeid.gramophone.model.CategoryInfo;
 import com.kabouzeid.gramophone.util.PreferenceUtil;
 
 import java.util.ArrayList;
+import java.util.List;
 
 
 public class LibraryPreferenceDialog extends DialogFragment {
@@ -29,7 +30,7 @@ public class LibraryPreferenceDialog extends DialogFragment {
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         View view = getActivity().getLayoutInflater().inflate(R.layout.preference_dialog_library_categories, null);
 
-        ArrayList<CategoryInfo> categoryInfos;
+        List<CategoryInfo> categoryInfos;
         if (savedInstanceState != null) {
             categoryInfos = savedInstanceState.getParcelableArrayList(PreferenceUtil.LIBRARY_CATEGORIES);
         } else {
@@ -62,16 +63,16 @@ public class LibraryPreferenceDialog extends DialogFragment {
     @Override
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
-        outState.putParcelableArrayList(PreferenceUtil.LIBRARY_CATEGORIES, adapter.getCategoryInfos());
+        outState.putParcelableArrayList(PreferenceUtil.LIBRARY_CATEGORIES, new ArrayList<>(adapter.getCategoryInfos()));
     }
 
-    private void updateCategories(ArrayList<CategoryInfo> categories) {
+    private void updateCategories(List<CategoryInfo> categories) {
         if (getSelected(categories) == 0) return;
 
         PreferenceUtil.getInstance(getContext()).setLibraryCategoryInfos(categories);
     }
 
-    private int getSelected(ArrayList<CategoryInfo> categories) {
+    private int getSelected(List<CategoryInfo> categories) {
         int selected = 0;
         for (CategoryInfo categoryInfo : categories) {
             if (categoryInfo.visible)

--- a/app/src/main/java/com/kabouzeid/gramophone/provider/BlacklistStore.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/provider/BlacklistStore.java
@@ -15,6 +15,7 @@ import com.kabouzeid.gramophone.util.PreferenceUtil;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.List;
 
 public class BlacklistStore extends SQLiteOpenHelper {
     private static BlacklistStore sInstance = null;
@@ -130,12 +131,12 @@ public class BlacklistStore extends SQLiteOpenHelper {
     }
 
     @NonNull
-    public ArrayList<String> getPaths() {
+    public List<String> getPaths() {
         Cursor cursor = getReadableDatabase().query(BlacklistStoreColumns.NAME,
                 new String[]{BlacklistStoreColumns.PATH},
                 null, null, null, null, null);
 
-        ArrayList<String> paths = new ArrayList<>();
+        List<String> paths = new ArrayList<>();
         if (cursor != null && cursor.moveToFirst()) {
             do {
                 paths.add(cursor.getString(0));

--- a/app/src/main/java/com/kabouzeid/gramophone/provider/MusicPlaybackQueueStore.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/provider/MusicPlaybackQueueStore.java
@@ -29,6 +29,7 @@ import com.kabouzeid.gramophone.loader.SongLoader;
 import com.kabouzeid.gramophone.model.Song;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Andrew Neal, modified for Phonograph by Karim Abou Zeid
@@ -129,7 +130,7 @@ public class MusicPlaybackQueueStore extends SQLiteOpenHelper {
         return sInstance;
     }
 
-    public synchronized void saveQueues(@NonNull final ArrayList<Song> playingQueue, @NonNull final ArrayList<Song> originalPlayingQueue) {
+    public synchronized void saveQueues(@NonNull final List<Song> playingQueue, @NonNull final List<Song> originalPlayingQueue) {
         saveQueue(PLAYING_QUEUE_TABLE_NAME, playingQueue);
         saveQueue(ORIGINAL_PLAYING_QUEUE_TABLE_NAME, originalPlayingQueue);
     }
@@ -140,7 +141,7 @@ public class MusicPlaybackQueueStore extends SQLiteOpenHelper {
      *
      * @param queue the queue to save
      */
-    private synchronized void saveQueue(final String tableName, @NonNull final ArrayList<Song> queue) {
+    private synchronized void saveQueue(final String tableName, @NonNull final List<Song> queue) {
         final SQLiteDatabase database = getWritableDatabase();
         database.beginTransaction();
 
@@ -183,17 +184,17 @@ public class MusicPlaybackQueueStore extends SQLiteOpenHelper {
     }
 
     @NonNull
-    public ArrayList<Song> getSavedPlayingQueue() {
+    public List<Song> getSavedPlayingQueue() {
         return getQueue(PLAYING_QUEUE_TABLE_NAME);
     }
 
     @NonNull
-    public ArrayList<Song> getSavedOriginalPlayingQueue() {
+    public List<Song> getSavedOriginalPlayingQueue() {
         return getQueue(ORIGINAL_PLAYING_QUEUE_TABLE_NAME);
     }
 
     @NonNull
-    private ArrayList<Song> getQueue(@NonNull final String tableName) {
+    private List<Song> getQueue(@NonNull final String tableName) {
         Cursor cursor = getReadableDatabase().query(tableName, null,
                 null, null, null, null, null);
         return SongLoader.getSongs(cursor);

--- a/app/src/main/java/com/kabouzeid/gramophone/service/MusicService.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/service/MusicService.java
@@ -27,12 +27,13 @@ import android.os.PowerManager;
 import android.os.Process;
 import android.preference.PreferenceManager;
 import android.provider.MediaStore;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import android.support.v4.media.MediaMetadataCompat;
 import android.support.v4.media.session.MediaSessionCompat;
 import android.support.v4.media.session.PlaybackStateCompat;
 import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.bumptech.glide.BitmapRequestBuilder;
 import com.bumptech.glide.Glide;
@@ -310,7 +311,7 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
                                 playlistSongs = ((AbsCustomPlaylist) playlist).getSongs(getApplicationContext());
                             } else {
                                 //noinspection unchecked
-                                playlistSongs = (List<Song>) (List) PlaylistSongLoader.getPlaylistSongList(getApplicationContext(), playlist.id);
+                                playlistSongs = (List) PlaylistSongLoader.getPlaylistSongList(getApplicationContext(), playlist.id);
                             }
                             if (!playlistSongs.isEmpty()) {
                                 if (shuffleMode == SHUFFLE_MODE_SHUFFLE) {

--- a/app/src/main/java/com/kabouzeid/gramophone/service/MusicService.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/service/MusicService.java
@@ -134,8 +134,8 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
     private AppWidgetCard appWidgetCard = AppWidgetCard.getInstance();
 
     private Playback playback;
-    private ArrayList<Song> playingQueue = new ArrayList<>();
-    private ArrayList<Song> originalPlayingQueue = new ArrayList<>();
+    private List<Song> playingQueue = new ArrayList<>();
+    private List<Song> originalPlayingQueue = new ArrayList<>();
     private int position = -1;
     private int nextPosition = -1;
     private int shuffleMode;
@@ -305,12 +305,12 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
                         Playlist playlist = intent.getParcelableExtra(INTENT_EXTRA_PLAYLIST);
                         int shuffleMode = intent.getIntExtra(INTENT_EXTRA_SHUFFLE_MODE, getShuffleMode());
                         if (playlist != null) {
-                            ArrayList<Song> playlistSongs;
+                            List<Song> playlistSongs;
                             if (playlist instanceof AbsCustomPlaylist) {
                                 playlistSongs = ((AbsCustomPlaylist) playlist).getSongs(getApplicationContext());
                             } else {
                                 //noinspection unchecked
-                                playlistSongs = (ArrayList<Song>) (List) PlaylistSongLoader.getPlaylistSongList(getApplicationContext(), playlist.id);
+                                playlistSongs = (List<Song>) (List) PlaylistSongLoader.getPlaylistSongList(getApplicationContext(), playlist.id);
                             }
                             if (!playlistSongs.isEmpty()) {
                                 if (shuffleMode == SHUFFLE_MODE_SHUFFLE) {
@@ -428,8 +428,8 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
 
     private synchronized void restoreQueuesAndPositionIfNecessary() {
         if (!queuesRestored && playingQueue.isEmpty()) {
-            ArrayList<Song> restoredQueue = MusicPlaybackQueueStore.getInstance(this).getSavedPlayingQueue();
-            ArrayList<Song> restoredOriginalQueue = MusicPlaybackQueueStore.getInstance(this).getSavedOriginalPlayingQueue();
+            List<Song> restoredQueue = MusicPlaybackQueueStore.getInstance(this).getSavedPlayingQueue();
+            List<Song> restoredOriginalQueue = MusicPlaybackQueueStore.getInstance(this).getSavedOriginalPlayingQueue();
             int restoredPosition = PreferenceManager.getDefaultSharedPreferences(this).getInt(SAVED_POSITION, -1);
             int restoredPositionInTrack = PreferenceManager.getDefaultSharedPreferences(this).getInt(SAVED_POSITION_IN_TRACK, -1);
 
@@ -677,7 +677,7 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
         return getPosition() == getPlayingQueue().size() - 1;
     }
 
-    public ArrayList<Song> getPlayingQueue() {
+    public List<Song> getPlayingQueue() {
         return playingQueue;
     }
 
@@ -700,7 +700,7 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
         }
     }
 
-    public void openQueue(@Nullable final ArrayList<Song> playingQueue, final int startPosition, final boolean startPlaying) {
+    public void openQueue(@Nullable final List<Song> playingQueue, final int startPosition, final boolean startPlaying) {
         if (playingQueue != null && !playingQueue.isEmpty() && startPosition >= 0 && startPosition < playingQueue.size()) {
             // it is important to copy the playing queue here first as we might add/remove songs later
             originalPlayingQueue = new ArrayList<>(playingQueue);
@@ -869,7 +869,7 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
         }
     }
 
-    public void playSongs(ArrayList<Song> songs, int shuffleMode) {
+    public void playSongs(List<Song> songs, int shuffleMode) {
         if (songs != null && !songs.isEmpty()) {
             if (shuffleMode == SHUFFLE_MODE_SHUFFLE) {
                 int startPosition = 0;

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/activities/AlbumDetailActivity.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/activities/AlbumDetailActivity.java
@@ -54,6 +54,7 @@ import com.kabouzeid.gramophone.util.PhonographColorUtil;
 import com.kabouzeid.gramophone.util.PreferenceUtil;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 import butterknife.BindView;
@@ -291,7 +292,7 @@ public class AlbumDetailActivity extends AbsSlidingMusicPanelActivity implements
     @Override
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         int id = item.getItemId();
-        final ArrayList<Song> songs = adapter.getDataSet();
+        final List<Song> songs = adapter.getDataSet();
         switch (id) {
             case R.id.action_sleep_timer:
                 new SleepTimerDialog().show(getSupportFragmentManager(), "SET_SLEEP_TIMER");

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/activities/ArtistDetailActivity.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/activities/ArtistDetailActivity.java
@@ -54,6 +54,7 @@ import com.kabouzeid.gramophone.util.PhonographColorUtil;
 import com.kabouzeid.gramophone.util.PreferenceUtil;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 import butterknife.BindView;
@@ -324,7 +325,7 @@ public class ArtistDetailActivity extends AbsSlidingMusicPanelActivity implement
     @Override
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         int id = item.getItemId();
-        final ArrayList<Song> songs = songAdapter.getDataSet();
+        final List<Song> songs = songAdapter.getDataSet();
         switch (id) {
             case R.id.action_sleep_timer:
                 new SleepTimerDialog().show(getSupportFragmentManager(), "SET_SLEEP_TIMER");

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/activities/GenreDetailActivity.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/activities/GenreDetailActivity.java
@@ -31,11 +31,12 @@ import com.kabouzeid.gramophone.util.ViewUtil;
 import com.simplecityapps.recyclerview_fastscroll.views.FastScrollRecyclerView;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
 
-public class GenreDetailActivity extends AbsSlidingMusicPanelActivity implements CabHolder, LoaderManager.LoaderCallbacks<ArrayList<Song>> {
+public class GenreDetailActivity extends AbsSlidingMusicPanelActivity implements CabHolder, LoaderManager.LoaderCallbacks<List<Song>> {
 
     private static final int LOADER_ID = LoaderIds.GENRE_DETAIL_ACTIVITY;
 
@@ -174,23 +175,23 @@ public class GenreDetailActivity extends AbsSlidingMusicPanelActivity implements
 
     @Override
     @NonNull
-    public Loader<ArrayList<Song>> onCreateLoader(int id, Bundle args) {
+    public Loader<List<Song>> onCreateLoader(int id, Bundle args) {
         return new GenreDetailActivity.AsyncGenreSongLoader(this, genre);
     }
 
     @Override
-    public void onLoadFinished(@NonNull Loader<ArrayList<Song>> loader, ArrayList<Song> data) {
+    public void onLoadFinished(@NonNull Loader<List<Song>> loader, List<Song> data) {
         if (adapter != null)
             adapter.swapDataSet(data);
     }
 
     @Override
-    public void onLoaderReset(@NonNull Loader<ArrayList<Song>> loader) {
+    public void onLoaderReset(@NonNull Loader<List<Song>> loader) {
         if (adapter != null)
             adapter.swapDataSet(new ArrayList<>());
     }
 
-    private static class AsyncGenreSongLoader extends WrappedAsyncTaskLoader<ArrayList<Song>> {
+    private static class AsyncGenreSongLoader extends WrappedAsyncTaskLoader<List<Song>> {
         private final Genre genre;
 
         public AsyncGenreSongLoader(Context context, Genre genre) {
@@ -199,7 +200,7 @@ public class GenreDetailActivity extends AbsSlidingMusicPanelActivity implements
         }
 
         @Override
-        public ArrayList<Song> loadInBackground() {
+        public List<Song> loadInBackground() {
             return GenreLoader.getSongs(getContext(), genre.id);
         }
     }

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/activities/MainActivity.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/activities/MainActivity.java
@@ -49,6 +49,7 @@ import com.kabouzeid.gramophone.util.PreferenceUtil;
 import com.sothree.slidinguppanel.SlidingUpPanelLayout;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -277,7 +278,7 @@ public class MainActivity extends AbsSlidingMusicPanelActivity {
         boolean handled = false;
 
         if (intent.getAction() != null && intent.getAction().equals(MediaStore.INTENT_ACTION_MEDIA_PLAY_FROM_SEARCH)) {
-            final ArrayList<Song> songs = SearchQueryHelper.getSongs(this, intent.getExtras());
+            final List<Song> songs = SearchQueryHelper.getSongs(this, intent.getExtras());
             if (MusicPlayerRemote.getShuffleMode() == MusicService.SHUFFLE_MODE_SHUFFLE) {
                 MusicPlayerRemote.openAndShuffleQueue(songs, true);
             } else {
@@ -293,7 +294,7 @@ public class MainActivity extends AbsSlidingMusicPanelActivity {
             final int id = (int) parseIdFromIntent(intent, "playlistId", "playlist");
             if (id >= 0) {
                 int position = intent.getIntExtra("position", 0);
-                ArrayList<Song> songs = new ArrayList<>(PlaylistSongLoader.getPlaylistSongList(this, id));
+                List<Song> songs = new ArrayList<>(PlaylistSongLoader.getPlaylistSongList(this, id));
                 MusicPlayerRemote.openQueue(songs, position, true);
                 handled = true;
             }

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/activities/PlaylistDetailActivity.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/activities/PlaylistDetailActivity.java
@@ -2,16 +2,17 @@ package com.kabouzeid.gramophone.ui.activities;
 
 import android.content.Context;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.loader.app.LoaderManager;
-import androidx.loader.content.Loader;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
-import androidx.appcompat.widget.Toolbar;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.widget.Toolbar;
+import androidx.loader.app.LoaderManager;
+import androidx.loader.content.Loader;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 
 import com.afollestad.materialcab.MaterialCab;
 import com.h6ah4i.android.widget.advrecyclerview.animator.GeneralItemAnimator;
@@ -267,7 +268,7 @@ public class PlaylistDetailActivity extends AbsSlidingMusicPanelActivity impleme
                 return ((AbsCustomPlaylist) playlist).getSongs(getContext());
             } else {
                 //noinspection unchecked
-                return (List<Song>) (List) PlaylistSongLoader.getPlaylistSongList(getContext(), playlist.id);
+                return (List) PlaylistSongLoader.getPlaylistSongList(getContext(), playlist.id);
             }
         }
     }

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/activities/PlaylistDetailActivity.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/activities/PlaylistDetailActivity.java
@@ -45,7 +45,7 @@ import java.util.List;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 
-public class PlaylistDetailActivity extends AbsSlidingMusicPanelActivity implements CabHolder, LoaderManager.LoaderCallbacks<ArrayList<Song>> {
+public class PlaylistDetailActivity extends AbsSlidingMusicPanelActivity implements CabHolder, LoaderManager.LoaderCallbacks<List<Song>> {
 
     private static final int LOADER_ID = LoaderIds.PLAYLIST_DETAIL_ACTIVITY;
 
@@ -237,23 +237,23 @@ public class PlaylistDetailActivity extends AbsSlidingMusicPanelActivity impleme
     }
 
     @Override
-    public Loader<ArrayList<Song>> onCreateLoader(int id, Bundle args) {
+    public Loader<List<Song>> onCreateLoader(int id, Bundle args) {
         return new AsyncPlaylistSongLoader(this, playlist);
     }
 
     @Override
-    public void onLoadFinished(Loader<ArrayList<Song>> loader, ArrayList<Song> data) {
+    public void onLoadFinished(Loader<List<Song>> loader, List<Song> data) {
         if (adapter != null)
             adapter.swapDataSet(data);
     }
 
     @Override
-    public void onLoaderReset(Loader<ArrayList<Song>> loader) {
+    public void onLoaderReset(Loader<List<Song>> loader) {
         if (adapter != null)
             adapter.swapDataSet(new ArrayList<>());
     }
 
-    private static class AsyncPlaylistSongLoader extends WrappedAsyncTaskLoader<ArrayList<Song>> {
+    private static class AsyncPlaylistSongLoader extends WrappedAsyncTaskLoader<List<Song>> {
         private final Playlist playlist;
 
         public AsyncPlaylistSongLoader(Context context, Playlist playlist) {
@@ -262,12 +262,12 @@ public class PlaylistDetailActivity extends AbsSlidingMusicPanelActivity impleme
         }
 
         @Override
-        public ArrayList<Song> loadInBackground() {
+        public List<Song> loadInBackground() {
             if (playlist instanceof AbsCustomPlaylist) {
                 return ((AbsCustomPlaylist) playlist).getSongs(getContext());
             } else {
                 //noinspection unchecked
-                return (ArrayList<Song>) (List) PlaylistSongLoader.getPlaylistSongList(getContext(), playlist.id);
+                return (List<Song>) (List) PlaylistSongLoader.getPlaylistSongList(getContext(), playlist.id);
             }
         }
     }

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/activities/base/AbsMusicServiceActivity.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/activities/base/AbsMusicServiceActivity.java
@@ -19,13 +19,14 @@ import com.kabouzeid.gramophone.service.MusicService;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
  */
 public abstract class AbsMusicServiceActivity extends AbsBaseActivity implements MusicServiceEventListener {
 
-    private final ArrayList<MusicServiceEventListener> mMusicServiceEventListeners = new ArrayList<>();
+    private final List<MusicServiceEventListener> mMusicServiceEventListeners = new ArrayList<>();
 
     private MusicPlayerRemote.ServiceToken serviceToken;
     private MusicStateReceiver musicStateReceiver;

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/activities/tageditor/AlbumTagEditorActivity.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/activities/tageditor/AlbumTagEditorActivity.java
@@ -180,8 +180,8 @@ public class AlbumTagEditorActivity extends AbsTagEditorActivity implements Text
     @NonNull
     @Override
     protected List<String> getSongPaths() {
-        ArrayList<Song> songs = AlbumLoader.getAlbum(this, getId()).songs;
-        ArrayList<String> paths = new ArrayList<>(songs.size());
+        List<Song> songs = AlbumLoader.getAlbum(this, getId()).songs;
+        List<String> paths = new ArrayList<>(songs.size());
         for (Song song : songs) {
             paths.add(song.data);
         }

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/activities/tageditor/SongTagEditorActivity.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/activities/tageditor/SongTagEditorActivity.java
@@ -112,7 +112,7 @@ public class SongTagEditorActivity extends AbsTagEditorActivity implements TextW
     @NonNull
     @Override
     protected List<String> getSongPaths() {
-        ArrayList<String> paths = new ArrayList<>(1);
+        List<String> paths = new ArrayList<>(1);
         paths.add(SongLoader.getSong(this, getId()).data);
         return paths;
     }

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/folders/FoldersFragment.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/folders/FoldersFragment.java
@@ -326,7 +326,7 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
     }
 
     @Override
-    public void onMultipleItemAction(MenuItem item, ArrayList<File> files) {
+    public void onMultipleItemAction(MenuItem item, List<File> files) {
         final int itemId = item.getItemId();
         new ListSongsAsyncTask(getActivity(), null, (songs, extra) -> {
             if (!songs.isEmpty()) {
@@ -347,8 +347,8 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
         }).execute(new ListSongsAsyncTask.LoadingInfo(files, AUDIO_FILE_FILTER, getFileComparator()));
     }
 
-    private ArrayList<File> toList(File file) {
-        ArrayList<File> files = new ArrayList<>(1);
+    private List<File> toList(File file) {
+        List<File> files = new ArrayList<>(1);
         files.add(file);
         return files;
     }
@@ -523,7 +523,7 @@ public class FoldersFragment extends AbsMainActivityFragment implements MainActi
         }
 
         @Override
-        protected ArrayList<Song> doInBackground(LoadingInfo... params) {
+        protected List<Song> doInBackground(LoadingInfo... params) {
             try {
                 LoadingInfo info = params[0];
                 List<File> files = FileUtil.listFilesDeep(info.files, info.fileFilter);

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/pager/AlbumsFragment.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/pager/AlbumsFragment.java
@@ -16,11 +16,12 @@ import com.kabouzeid.gramophone.model.Album;
 import com.kabouzeid.gramophone.util.PreferenceUtil;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
  */
-public class AlbumsFragment extends AbsLibraryPagerRecyclerViewCustomGridSizeFragment<AlbumAdapter, GridLayoutManager> implements LoaderManager.LoaderCallbacks<ArrayList<Album>> {
+public class AlbumsFragment extends AbsLibraryPagerRecyclerViewCustomGridSizeFragment<AlbumAdapter, GridLayoutManager> implements LoaderManager.LoaderCallbacks<List<Album>> {
 
     private static final int LOADER_ID = LoaderIds.ALBUMS_FRAGMENT;
 
@@ -40,7 +41,7 @@ public class AlbumsFragment extends AbsLibraryPagerRecyclerViewCustomGridSizeFra
     protected AlbumAdapter createAdapter() {
         int itemLayoutRes = getItemLayoutRes();
         notifyLayoutResChanged(itemLayoutRes);
-        ArrayList<Album> dataSet = getAdapter() == null ? new ArrayList<>() : getAdapter().getDataSet();
+        List<Album> dataSet = getAdapter() == null ? new ArrayList<>() : getAdapter().getDataSet();
         return new AlbumAdapter(
                 getLibraryFragment().getMainActivity(),
                 dataSet,
@@ -116,27 +117,27 @@ public class AlbumsFragment extends AbsLibraryPagerRecyclerViewCustomGridSizeFra
     }
 
     @Override
-    public Loader<ArrayList<Album>> onCreateLoader(int id, Bundle args) {
+    public Loader<List<Album>> onCreateLoader(int id, Bundle args) {
         return new AsyncAlbumLoader(getActivity());
     }
 
     @Override
-    public void onLoadFinished(Loader<ArrayList<Album>> loader, ArrayList<Album> data) {
+    public void onLoadFinished(Loader<List<Album>> loader, List<Album> data) {
         getAdapter().swapDataSet(data);
     }
 
     @Override
-    public void onLoaderReset(Loader<ArrayList<Album>> loader) {
+    public void onLoaderReset(Loader<List<Album>> loader) {
         getAdapter().swapDataSet(new ArrayList<>());
     }
 
-    private static class AsyncAlbumLoader extends WrappedAsyncTaskLoader<ArrayList<Album>> {
+    private static class AsyncAlbumLoader extends WrappedAsyncTaskLoader<List<Album>> {
         public AsyncAlbumLoader(Context context) {
             super(context);
         }
 
         @Override
-        public ArrayList<Album> loadInBackground() {
+        public List<Album> loadInBackground() {
             return AlbumLoader.getAllAlbums(getContext());
         }
     }

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/pager/ArtistsFragment.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/pager/ArtistsFragment.java
@@ -16,11 +16,12 @@ import com.kabouzeid.gramophone.model.Artist;
 import com.kabouzeid.gramophone.util.PreferenceUtil;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
  */
-public class ArtistsFragment extends AbsLibraryPagerRecyclerViewCustomGridSizeFragment<ArtistAdapter, GridLayoutManager> implements LoaderManager.LoaderCallbacks<ArrayList<Artist>> {
+public class ArtistsFragment extends AbsLibraryPagerRecyclerViewCustomGridSizeFragment<ArtistAdapter, GridLayoutManager> implements LoaderManager.LoaderCallbacks<List<Artist>> {
 
     private static final int LOADER_ID = LoaderIds.ARTISTS_FRAGMENT;
 
@@ -41,7 +42,7 @@ public class ArtistsFragment extends AbsLibraryPagerRecyclerViewCustomGridSizeFr
     protected ArtistAdapter createAdapter() {
         int itemLayoutRes = getItemLayoutRes();
         notifyLayoutResChanged(itemLayoutRes);
-        ArrayList<Artist> dataSet = getAdapter() == null ? new ArrayList<>() : getAdapter().getDataSet();
+        List<Artist> dataSet = getAdapter() == null ? new ArrayList<>() : getAdapter().getDataSet();
         return new ArtistAdapter(
                 getLibraryFragment().getMainActivity(),
                 dataSet,
@@ -118,29 +119,29 @@ public class ArtistsFragment extends AbsLibraryPagerRecyclerViewCustomGridSizeFr
 
 
     @Override
-    public Loader<ArrayList<Artist>> onCreateLoader(int id, Bundle args) {
+    public Loader<List<Artist>> onCreateLoader(int id, Bundle args) {
         return new AsyncArtistLoader(getActivity());
     }
 
 
     @Override
-    public void onLoadFinished(Loader<ArrayList<Artist>> loader, ArrayList<Artist> data) {
+    public void onLoadFinished(Loader<List<Artist>> loader, List<Artist> data) {
         getAdapter().swapDataSet(data);
     }
 
 
     @Override
-    public void onLoaderReset(Loader<ArrayList<Artist>> loader) {
+    public void onLoaderReset(Loader<List<Artist>> loader) {
         getAdapter().swapDataSet(new ArrayList<>());
     }
 
-    private static class AsyncArtistLoader extends WrappedAsyncTaskLoader<ArrayList<Artist>> {
+    private static class AsyncArtistLoader extends WrappedAsyncTaskLoader<List<Artist>> {
         public AsyncArtistLoader(Context context) {
             super(context);
         }
 
         @Override
-        public ArrayList<Artist> loadInBackground() {
+        public List<Artist> loadInBackground() {
             return ArtistLoader.getAllArtists(getContext());
         }
     }

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/pager/GenresFragment.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/pager/GenresFragment.java
@@ -15,8 +15,9 @@ import com.kabouzeid.gramophone.misc.WrappedAsyncTaskLoader;
 import com.kabouzeid.gramophone.model.Genre;
 
 import java.util.ArrayList;
+import java.util.List;
 
-public class GenresFragment extends AbsLibraryPagerRecyclerViewFragment<GenreAdapter, LinearLayoutManager> implements LoaderManager.LoaderCallbacks<ArrayList<Genre>> {
+public class GenresFragment extends AbsLibraryPagerRecyclerViewFragment<GenreAdapter, LinearLayoutManager> implements LoaderManager.LoaderCallbacks<List<Genre>> {
 
     private static final int LOADER_ID = LoaderIds.GENRES_FRAGMENT;
 
@@ -35,7 +36,7 @@ public class GenresFragment extends AbsLibraryPagerRecyclerViewFragment<GenreAda
     @NonNull
     @Override
     protected GenreAdapter createAdapter() {
-        ArrayList<Genre> dataSet = getAdapter() == null ? new ArrayList<>() : getAdapter().getDataSet();
+        List<Genre> dataSet = getAdapter() == null ? new ArrayList<>() : getAdapter().getDataSet();
         return new GenreAdapter(getLibraryFragment().getMainActivity(), dataSet, R.layout.item_list_no_image);
     }
 
@@ -51,27 +52,27 @@ public class GenresFragment extends AbsLibraryPagerRecyclerViewFragment<GenreAda
 
     @Override
     @NonNull
-    public Loader<ArrayList<Genre>> onCreateLoader(int id, Bundle args) {
+    public Loader<List<Genre>> onCreateLoader(int id, Bundle args) {
         return new GenresFragment.AsyncGenreLoader(getActivity());
     }
 
     @Override
-    public void onLoadFinished(@NonNull Loader<ArrayList<Genre>> loader, ArrayList<Genre> data) {
+    public void onLoadFinished(@NonNull Loader<List<Genre>> loader, List<Genre> data) {
         getAdapter().swapDataSet(data);
     }
 
     @Override
-    public void onLoaderReset(@NonNull Loader<ArrayList<Genre>> loader) {
+    public void onLoaderReset(@NonNull Loader<List<Genre>> loader) {
         getAdapter().swapDataSet(new ArrayList<>());
     }
 
-    private static class AsyncGenreLoader extends WrappedAsyncTaskLoader<ArrayList<Genre>> {
+    private static class AsyncGenreLoader extends WrappedAsyncTaskLoader<List<Genre>> {
         public AsyncGenreLoader(Context context) {
             super(context);
         }
 
         @Override
-        public ArrayList<Genre> loadInBackground() {
+        public List<Genre> loadInBackground() {
             return GenreLoader.getAllGenres(getContext());
         }
     }

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/pager/PlaylistsFragment.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/pager/PlaylistsFragment.java
@@ -2,6 +2,7 @@ package com.kabouzeid.gramophone.ui.fragments.mainactivity.library.pager;
 
 import android.content.Context;
 import android.os.Bundle;
+
 import androidx.annotation.NonNull;
 import androidx.loader.app.LoaderManager;
 import androidx.loader.content.Loader;
@@ -18,11 +19,12 @@ import com.kabouzeid.gramophone.model.smartplaylist.LastAddedPlaylist;
 import com.kabouzeid.gramophone.model.smartplaylist.MyTopTracksPlaylist;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
  */
-public class PlaylistsFragment extends AbsLibraryPagerRecyclerViewFragment<PlaylistAdapter, LinearLayoutManager> implements LoaderManager.LoaderCallbacks<ArrayList<Playlist>> {
+public class PlaylistsFragment extends AbsLibraryPagerRecyclerViewFragment<PlaylistAdapter, LinearLayoutManager> implements LoaderManager.LoaderCallbacks<List<Playlist>> {
 
     private static final int LOADER_ID = LoaderIds.PLAYLISTS_FRAGMENT;
 
@@ -41,7 +43,7 @@ public class PlaylistsFragment extends AbsLibraryPagerRecyclerViewFragment<Playl
     @NonNull
     @Override
     protected PlaylistAdapter createAdapter() {
-        ArrayList<Playlist> dataSet = getAdapter() == null ? new ArrayList<>() : getAdapter().getDataSet();
+        List<Playlist> dataSet = getAdapter() == null ? new ArrayList<>() : getAdapter().getDataSet();
         return new PlaylistAdapter(getLibraryFragment().getMainActivity(), dataSet, R.layout.item_list_single_row, getLibraryFragment());
     }
 
@@ -56,27 +58,27 @@ public class PlaylistsFragment extends AbsLibraryPagerRecyclerViewFragment<Playl
     }
 
     @Override
-    public Loader<ArrayList<Playlist>> onCreateLoader(int id, Bundle args) {
+    public Loader<List<Playlist>> onCreateLoader(int id, Bundle args) {
         return new AsyncPlaylistLoader(getActivity());
     }
 
     @Override
-    public void onLoadFinished(Loader<ArrayList<Playlist>> loader, ArrayList<Playlist> data) {
+    public void onLoadFinished(Loader<List<Playlist>> loader, List<Playlist> data) {
         getAdapter().swapDataSet(data);
     }
 
     @Override
-    public void onLoaderReset(Loader<ArrayList<Playlist>> loader) {
+    public void onLoaderReset(Loader<List<Playlist>> loader) {
         getAdapter().swapDataSet(new ArrayList<>());
     }
 
-    private static class AsyncPlaylistLoader extends WrappedAsyncTaskLoader<ArrayList<Playlist>> {
+    private static class AsyncPlaylistLoader extends WrappedAsyncTaskLoader<List<Playlist>> {
         public AsyncPlaylistLoader(Context context) {
             super(context);
         }
 
-        private static ArrayList<Playlist> getAllPlaylists(Context context) {
-            ArrayList<Playlist> playlists = new ArrayList<>();
+        private static List<Playlist> getAllPlaylists(Context context) {
+            List<Playlist> playlists = new ArrayList<>();
 
             playlists.add(new LastAddedPlaylist(context));
             playlists.add(new HistoryPlaylist(context));
@@ -88,7 +90,7 @@ public class PlaylistsFragment extends AbsLibraryPagerRecyclerViewFragment<Playl
         }
 
         @Override
-        public ArrayList<Playlist> loadInBackground() {
+        public List<Playlist> loadInBackground() {
             return getAllPlaylists(getContext());
         }
     }

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/pager/SongsFragment.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/pager/SongsFragment.java
@@ -17,11 +17,12 @@ import com.kabouzeid.gramophone.model.Song;
 import com.kabouzeid.gramophone.util.PreferenceUtil;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Karim Abou Zeid (kabouzeid)
  */
-public class SongsFragment extends AbsLibraryPagerRecyclerViewCustomGridSizeFragment<SongAdapter, GridLayoutManager> implements LoaderManager.LoaderCallbacks<ArrayList<Song>> {
+public class SongsFragment extends AbsLibraryPagerRecyclerViewCustomGridSizeFragment<SongAdapter, GridLayoutManager> implements LoaderManager.LoaderCallbacks<List<Song>> {
 
     private static final int LOADER_ID = LoaderIds.SONGS_FRAGMENT;
 
@@ -43,7 +44,7 @@ public class SongsFragment extends AbsLibraryPagerRecyclerViewCustomGridSizeFrag
         int itemLayoutRes = getItemLayoutRes();
         notifyLayoutResChanged(itemLayoutRes);
         boolean usePalette = loadUsePalette();
-        ArrayList<Song> dataSet = getAdapter() == null ? new ArrayList<>() : getAdapter().getDataSet();
+        List<Song> dataSet = getAdapter() == null ? new ArrayList<>() : getAdapter().getDataSet();
 
         if (getGridSize() <= getMaxGridSizeForList()) {
             return new ShuffleButtonSongAdapter(

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/pager/SongsFragment.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/fragments/mainactivity/library/pager/SongsFragment.java
@@ -129,27 +129,27 @@ public class SongsFragment extends AbsLibraryPagerRecyclerViewCustomGridSizeFrag
     }
 
     @Override
-    public Loader<ArrayList<Song>> onCreateLoader(int id, Bundle args) {
+    public Loader<List<Song>> onCreateLoader(int id, Bundle args) {
         return new AsyncSongLoader(getActivity());
     }
 
     @Override
-    public void onLoadFinished(Loader<ArrayList<Song>> loader, ArrayList<Song> data) {
+    public void onLoadFinished(Loader<List<Song>> loader, List<Song> data) {
         getAdapter().swapDataSet(data);
     }
 
     @Override
-    public void onLoaderReset(Loader<ArrayList<Song>> loader) {
+    public void onLoaderReset(Loader<List<Song>> loader) {
         getAdapter().swapDataSet(new ArrayList<>());
     }
 
-    private static class AsyncSongLoader extends WrappedAsyncTaskLoader<ArrayList<Song>> {
+    private static class AsyncSongLoader extends WrappedAsyncTaskLoader<List<Song>> {
         public AsyncSongLoader(Context context) {
             super(context);
         }
 
         @Override
-        public ArrayList<Song> loadInBackground() {
+        public List<Song> loadInBackground() {
             return SongLoader.getAllSongs(getContext());
         }
     }

--- a/app/src/main/java/com/kabouzeid/gramophone/util/FileUtil.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/util/FileUtil.java
@@ -32,7 +32,7 @@ public final class FileUtil {
     }
 
     @NonNull
-    public static ArrayList<Song> matchFilesWithMediaStore(@NonNull Context context, @Nullable List<File> files) {
+    public static List<Song> matchFilesWithMediaStore(@NonNull Context context, @Nullable List<File> files) {
         return SongLoader.getSongs(makeSongCursor(context, files));
     }
 

--- a/app/src/main/java/com/kabouzeid/gramophone/util/MusicUtil.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/util/MusicUtil.java
@@ -376,7 +376,7 @@ public class MusicUtil {
                 String filename = Pattern.quote(FileUtil.stripExtension(file.getName()));
                 String songtitle = Pattern.quote(song.title);
 
-                final ArrayList<Pattern> patterns = new ArrayList<>();
+                final List<Pattern> patterns = new ArrayList<>();
                 patterns.add(Pattern.compile(String.format(format, filename), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE));
                 patterns.add(Pattern.compile(String.format(format, songtitle), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE));
 

--- a/app/src/main/java/com/kabouzeid/gramophone/util/PlaylistsUtil.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/util/PlaylistsUtil.java
@@ -82,7 +82,7 @@ public class PlaylistsUtil {
         return id;
     }
 
-    public static void deletePlaylists(@NonNull final Context context, @NonNull final ArrayList<Playlist> playlists) {
+    public static void deletePlaylists(@NonNull final Context context, @NonNull final List<Playlist> playlists) {
         final StringBuilder selection = new StringBuilder();
         selection.append(MediaStore.Audio.Playlists._ID + " IN (");
         for (int i = 0; i < playlists.size(); i++) {

--- a/app/src/main/java/com/kabouzeid/gramophone/util/PreferenceUtil.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/util/PreferenceUtil.java
@@ -22,6 +22,7 @@ import com.kabouzeid.gramophone.ui.fragments.player.NowPlayingScreen;
 import java.io.File;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.List;
 
 public final class PreferenceUtil {
     public static final String GENERAL_THEME = "general_theme";
@@ -498,9 +499,9 @@ public final class PreferenceUtil {
         return mPreferences.getBoolean(INITIALIZED_BLACKLIST, false);
     }
 
-    public void setLibraryCategoryInfos(ArrayList<CategoryInfo> categories) {
+    public void setLibraryCategoryInfos(List<CategoryInfo> categories) {
         Gson gson = new Gson();
-        Type collectionType = new TypeToken<ArrayList<CategoryInfo>>() {
+        Type collectionType = new TypeToken<List<CategoryInfo>>() {
         }.getType();
 
         final SharedPreferences.Editor editor = mPreferences.edit();
@@ -508,11 +509,11 @@ public final class PreferenceUtil {
         editor.apply();
     }
 
-    public ArrayList<CategoryInfo> getLibraryCategoryInfos() {
+    public List<CategoryInfo> getLibraryCategoryInfos() {
         String data = mPreferences.getString(LIBRARY_CATEGORIES, null);
         if (data != null) {
             Gson gson = new Gson();
-            Type collectionType = new TypeToken<ArrayList<CategoryInfo>>() {
+            Type collectionType = new TypeToken<List<CategoryInfo>>() {
             }.getType();
 
             try {
@@ -525,8 +526,8 @@ public final class PreferenceUtil {
         return getDefaultLibraryCategoryInfos();
     }
 
-    public ArrayList<CategoryInfo> getDefaultLibraryCategoryInfos() {
-        ArrayList<CategoryInfo> defaultCategoryInfos = new ArrayList<>(5);
+    public List<CategoryInfo> getDefaultLibraryCategoryInfos() {
+        List<CategoryInfo> defaultCategoryInfos = new ArrayList<>(5);
         defaultCategoryInfos.add(new CategoryInfo(CategoryInfo.Category.SONGS, true));
         defaultCategoryInfos.add(new CategoryInfo(CategoryInfo.Category.ALBUMS, true));
         defaultCategoryInfos.add(new CategoryInfo(CategoryInfo.Category.ARTISTS, true));


### PR DESCRIPTION
According to the reasons mentioned in Effective Java (3rd Edition) Item 64, it is better to use interfaces compared to actual classes, I replaced all usages of `ArrayList<>` with `List`.

This gives us more flexibility in the future!