### PR TITLE
Fix SlidingPanel by updating dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -109,7 +109,7 @@ dependencies {
     implementation 'com.github.kabouzeid:app-theme-helper:1.3.10'
     implementation 'com.github.kabouzeid:RecyclerView-FastScroll:1.0.16-kmod'
     implementation 'com.github.kabouzeid:SeekArc:1.2-kmod'
-    implementation 'com.github.kabouzeid:AndroidSlidingUpPanel:3.3.3-kmod'
+    implementation 'com.github.kabouzeid:AndroidSlidingUpPanel:e613c68d35'
     implementation 'com.afollestad.material-dialogs:core:0.9.6.0'
     implementation 'com.afollestad.material-dialogs:commons:0.9.6.0'
     implementation 'com.afollestad:material-cab:0.1.12'


### PR DESCRIPTION
Fixes #668 

Jitpack no longer has the latest build of kabouzeid/AndroidSlidingUpPanel (which is 3.3.0-kmod3, not 3.3.3-kmod). The older build was used due to #658 

Jitpack however does have the build of commit kabouzeid/AndroidSlidingUpPanel@e613c68d35 still hosted, which is the 3.3.0-kmod3 tagged commit. Thus, use this commit as it fixes the aforementioned issue