### PR TITLE
Show both 'Artist' and 'Album Artist' fields in tag editor activities

### DIFF
--- a/app/src/main/java/com/kabouzeid/gramophone/ui/activities/tageditor/AlbumTagEditorActivity.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/activities/tageditor/AlbumTagEditorActivity.java
@@ -47,6 +47,8 @@ public class AlbumTagEditorActivity extends AbsTagEditorActivity implements Text
 
     @BindView(R.id.title)
     EditText albumTitle;
+    @BindView(R.id.artist)
+    EditText artist;
     @BindView(R.id.album_artist)
     EditText albumArtist;
     @BindView(R.id.genre)
@@ -71,6 +73,7 @@ public class AlbumTagEditorActivity extends AbsTagEditorActivity implements Text
     private void setUpViews() {
         fillViewsWithFileTags();
         albumTitle.addTextChangedListener(this);
+        artist.addTextChangedListener(this);
         albumArtist.addTextChangedListener(this);
         genre.addTextChangedListener(this);
         year.addTextChangedListener(this);
@@ -79,6 +82,7 @@ public class AlbumTagEditorActivity extends AbsTagEditorActivity implements Text
 
     private void fillViewsWithFileTags() {
         albumTitle.setText(getAlbumTitle());
+        artist.setText(getArtistName());
         albumArtist.setText(getAlbumArtistName());
         genre.setText(getGenreName());
         year.setText(getSongYear());
@@ -164,7 +168,7 @@ public class AlbumTagEditorActivity extends AbsTagEditorActivity implements Text
         Map<FieldKey, String> fieldKeyValueMap = new EnumMap<>(FieldKey.class);
         fieldKeyValueMap.put(FieldKey.ALBUM, albumTitle.getText().toString());
         //android seems not to recognize album_artist field so we additionally write the normal artist field
-        fieldKeyValueMap.put(FieldKey.ARTIST, albumArtist.getText().toString());
+        fieldKeyValueMap.put(FieldKey.ARTIST, artist.getText().toString());
         fieldKeyValueMap.put(FieldKey.ALBUM_ARTIST, albumArtist.getText().toString());
         fieldKeyValueMap.put(FieldKey.GENRE, genre.getText().toString());
         fieldKeyValueMap.put(FieldKey.YEAR, year.getText().toString());

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/activities/tageditor/SongTagEditorActivity.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/activities/tageditor/SongTagEditorActivity.java
@@ -29,6 +29,8 @@ public class SongTagEditorActivity extends AbsTagEditorActivity implements TextW
     EditText albumTitle;
     @BindView(R.id.artist)
     EditText artist;
+    @BindView(R.id.album_artist)
+    EditText albumArtist;
     @BindView(R.id.genre)
     EditText genre;
     @BindView(R.id.year)
@@ -55,6 +57,7 @@ public class SongTagEditorActivity extends AbsTagEditorActivity implements TextW
         songTitle.addTextChangedListener(this);
         albumTitle.addTextChangedListener(this);
         artist.addTextChangedListener(this);
+        albumArtist.addTextChangedListener(this);
         genre.addTextChangedListener(this);
         year.addTextChangedListener(this);
         trackNumber.addTextChangedListener(this);
@@ -65,6 +68,7 @@ public class SongTagEditorActivity extends AbsTagEditorActivity implements TextW
         songTitle.setText(getSongTitle());
         albumTitle.setText(getAlbumTitle());
         artist.setText(getArtistName());
+        albumArtist.setText(getAlbumArtistName());
         genre.setText(getGenreName());
         year.setText(getSongYear());
         trackNumber.setText(getTrackNumber());
@@ -97,6 +101,7 @@ public class SongTagEditorActivity extends AbsTagEditorActivity implements TextW
         fieldKeyValueMap.put(FieldKey.TITLE, songTitle.getText().toString());
         fieldKeyValueMap.put(FieldKey.ALBUM, albumTitle.getText().toString());
         fieldKeyValueMap.put(FieldKey.ARTIST, artist.getText().toString());
+        fieldKeyValueMap.put(FieldKey.ALBUM_ARTIST, albumArtist.getText().toString());
         fieldKeyValueMap.put(FieldKey.GENRE, genre.getText().toString());
         fieldKeyValueMap.put(FieldKey.YEAR, year.getText().toString());
         fieldKeyValueMap.put(FieldKey.TRACK, trackNumber.getText().toString());

--- a/app/src/main/res/layout/activity_album_tag_editor.xml
+++ b/app/src/main/res/layout/activity_album_tag_editor.xml
@@ -81,6 +81,24 @@
                     android:layout_height="wrap_content">
 
                     <EditText
+                        android:id="@+id/artist"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:fontFamily="sans-serif"
+                        android:gravity="center_vertical"
+                        android:hint="@string/artist"
+                        android:inputType="text|textCapWords"
+                        android:singleLine="true"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Title" />
+
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content">
+
+                    <EditText
                         android:id="@+id/album_artist"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_song_tag_editor.xml
+++ b/app/src/main/res/layout/activity_song_tag_editor.xml
@@ -108,6 +108,24 @@
                     android:layout_height="wrap_content">
 
                     <EditText
+                        android:id="@+id/album_artist"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:fontFamily="sans-serif"
+                        android:gravity="center_vertical"
+                        android:hint="@string/album_artist"
+                        android:inputType="text|textCapWords"
+                        android:singleLine="true"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Title" />
+
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content">
+
+                    <EditText
                         android:id="@+id/genre"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"


### PR DESCRIPTION
In the album tag editor, if the Album Artist field is empty when saving, the Artist tag will be deleted. This fixes that bug by adding an Artist field, and also adds an Album Artist field to the song tag editor.