### PR TITLE
Support Android 10, atleast for now

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Phonograph.Light"
+        android:requestLegacyExternalStorage="true"
         tools:ignore="UnusedAttribute">
         <activity android:name=".ui.activities.MainActivity">
             <intent-filter>

--- a/app/src/main/java/com/kabouzeid/gramophone/service/MusicService.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/service/MusicService.java
@@ -561,7 +561,7 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
                 new PlaybackStateCompat.Builder()
                         .setActions(MEDIA_SESSION_ACTIONS)
                         .setState(isPlaying() ? PlaybackStateCompat.STATE_PLAYING : PlaybackStateCompat.STATE_PAUSED,
-                                getPosition(), 1)
+                                getSongProgressMillis(), 1)
                         .build());
     }
 
@@ -1346,6 +1346,8 @@ public class MusicService extends Service implements SharedPreferences.OnSharedP
         }
 
         public void notifySeek() {
+            updateMediaSessionMetaData();
+            updateMediaSessionPlaybackState();
             mHandler.removeCallbacks(this);
             mHandler.postDelayed(this, THROTTLE);
         }


### PR DESCRIPTION
Lot of the open issues are about issues on Android 10, namely storage issues and the seekbar on notification.

The notification seekbar is addressed by this [commit](https://github.com/kabouzeid/Phonograph/commit/071723a150df9fdc3017ad1e7c3df0d78b998ec5)

The storage issue is related to Scoped Storage, opting out of which is done by [this](https://github.com/kabouzeid/Phonograph/commit/aa979888ef82ee461b8a687bc4b68b106f97344a) commit. This is only a temporary solution. Better solution.

Also, another method to address the issues, is to revert to targeting SDK version of 28.