### PR TITLE
Fixes to the Dark and Black themes

### DIFF
--- a/app/src/main/res/values/styles_parents.xml
+++ b/app/src/main/res/values/styles_parents.xml
@@ -12,9 +12,10 @@
         <item name="rectSelector">@drawable/rect_selector_dark</item>
         <item name="rectSelectorStrong">@drawable/rect_selector_strong_dark</item>
 
-        <item name="cardBackgroundColor">@color/md_grey_800</item>
+        <item name="android:colorBackground">@color/md_grey_900</item>
+        <item name="cardBackgroundColor">@color/md_grey_850</item>
 
-        <item name="defaultFooterColor">@color/md_grey_900</item>
+        <item name="defaultFooterColor">@color/md_grey_800</item>
 
         <item name="dividerColor">@color/md_divider_white</item>
         <item name="iconColor">@color/ate_secondary_text_dark</item>

--- a/app/src/main/res/values/styles_parents.xml
+++ b/app/src/main/res/values/styles_parents.xml
@@ -60,10 +60,11 @@
     </style>
 
     <style name="Theme.Phonograph.Base.Black" parent="@style/Theme.Phonograph.Base">
+        <item name="android:colorBackground">@android:color/black</item>
         <item name="android:windowBackground">@android:color/black</item>
         <item name="dividerColor">#18FFFFFF</item>
         <item name="defaultFooterColor">@color/md_grey_800</item>
-        <item name="cardBackgroundColor">@color/md_grey_900</item>
+        <item name="cardBackgroundColor">@color/md_black_1000</item>
         <item name="md_background_color">@color/md_grey_900</item>
     </style>
 


### PR DESCRIPTION
- Black theme now finally uses actual #000000 black throughout instead of it being half-grey.

- Dark theme updated with darker shades of grey to give it a more modern look (similar shades of grey to that of Google's MD2.0 apps).