### PR TITLE
F-droid flavour

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,7 +61,6 @@ android {
             minifyEnabled true
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            signingConfig signingConfigs.release
         }
         debug {
             applicationIdSuffix '.debug'
@@ -80,6 +79,21 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
+    }
+    flavorDimensions "version"
+    productFlavors {
+        productFlavors {
+            play {
+                dimension "version"
+                signingConfig signingConfigs.release
+            }
+            fdroid {
+                dimension "version"
+                // applicationIdSuffix ".fdroid"
+                versionNameSuffix ' (F-Droid)'
+
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/kabouzeid/gramophone/App.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/App.java
@@ -69,7 +69,10 @@ public class App extends Application {
     }
 
     public static boolean isProVersion() {
-        return BuildConfig.DEBUG || app.billingProcessor.isPurchased(PRO_VERSION_PRODUCT_ID);
+        if (BuildConfig.DEBUG || BuildConfig.FLAVOR.equals("fdroid")) {
+            return true;
+        }
+        return app.billingProcessor.isPurchased(PRO_VERSION_PRODUCT_ID);
     }
 
     private static OnProVersionChangedListener onProVersionChangedListener;


### PR DESCRIPTION
Just a stripped down version #276 

Allow pro-features on builds at F-droid, fixes #885 .
In total, there's 4 different builds: `fdroidDebug`, `fdroidRelease`, `playDebug`, and` playRelease`. Only `playRelease` is configured to sign the apk with developer's personal key.
The versionName of F-droid apk is suffixed suitably.
The applicationId isn't changed to allow existing F-droid version users to update current version.

The only change applicable for developer seems to change the build variant from `Release` to `playRelease`
