### PR TITLE
Issue 918

### DIFF
--- a/app/src/main/java/com/kabouzeid/gramophone/loader/LastAddedLoader.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/loader/LastAddedLoader.java
@@ -3,19 +3,26 @@ package com.kabouzeid.gramophone.loader;
 import android.content.Context;
 import android.database.Cursor;
 import android.provider.MediaStore;
+
 import androidx.annotation.NonNull;
 
 import com.kabouzeid.gramophone.model.Song;
 import com.kabouzeid.gramophone.util.PreferenceUtil;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class LastAddedLoader {
 
     @NonNull
     public static List<Song> getLastAddedSongs(@NonNull Context context) {
-        return SongLoader.getSongs(makeLastAddedCursor(context));
+        List<Song> songs = SongLoader.getSongs(makeLastAddedCursor(context));
+
+        if (PreferenceUtil.getInstance(context).isLastAddedItemShowLimitEnable()) {
+            int limit = PreferenceUtil.getInstance(context).getLastAddedItemShowLimit();
+            return songs.subList(0, Math.min(songs.size(), limit));
+        } else {
+            return songs;
+        }
     }
 
     public static Cursor makeLastAddedCursor(@NonNull final Context context) {

--- a/app/src/main/java/com/kabouzeid/gramophone/preferences/LastAddedLimitPreference.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/preferences/LastAddedLimitPreference.java
@@ -1,0 +1,26 @@
+package com.kabouzeid.gramophone.preferences;
+
+import android.content.Context;
+import android.util.AttributeSet;
+
+import com.kabouzeid.appthemehelper.common.prefs.supportv7.ATEDialogPreference;
+
+public class LastAddedLimitPreference extends ATEDialogPreference {
+
+    public LastAddedLimitPreference(Context context) {
+        super(context);
+    }
+
+    public LastAddedLimitPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public LastAddedLimitPreference(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    public LastAddedLimitPreference(Context context, AttributeSet attrs, int defStyleAttr,
+                                    int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+    }
+}

--- a/app/src/main/java/com/kabouzeid/gramophone/preferences/LastAddedLimitPreferenceDialog.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/preferences/LastAddedLimitPreferenceDialog.java
@@ -1,0 +1,70 @@
+package com.kabouzeid.gramophone.preferences;
+
+import android.app.Dialog;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.DialogFragment;
+
+import com.afollestad.materialdialogs.MaterialDialog;
+import com.google.android.material.switchmaterial.SwitchMaterial;
+import com.google.android.material.textfield.TextInputEditText;
+import com.kabouzeid.gramophone.R;
+import com.kabouzeid.gramophone.util.PreferenceUtil;
+
+public class LastAddedLimitPreferenceDialog extends DialogFragment {
+
+    public static LastAddedLimitPreferenceDialog newInstance() {
+        return new LastAddedLimitPreferenceDialog();
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        View view = requireActivity().getLayoutInflater()
+                .inflate(R.layout.preference_dailog_last_added_limit ,null);
+
+        PreferenceUtil preferenceUtil = PreferenceUtil.getInstance(requireContext());
+
+        SwitchMaterial enableLimit = view.findViewById(R.id.last_added_limit_switch);
+        TextInputEditText limitText = view.findViewById(R.id.last_added_limit_text);
+
+        enableLimit.setChecked(preferenceUtil.isLastAddedItemShowLimitEnable());
+        limitText.setEnabled(enableLimit.isChecked());
+
+        enableLimit.setOnCheckedChangeListener((compoundButton, b) -> limitText.setEnabled(b));
+
+        limitText.setText(String.valueOf(preferenceUtil.getLastAddedItemShowLimit()));
+
+        return new MaterialDialog.Builder(requireContext())
+                .title(getResources().getString(R.string.last_added_items_show_limit))
+                .autoDismiss(false)
+                .customView(view, false)
+                .positiveText(android.R.string.ok)
+                .negativeText(android.R.string.cancel)
+                .onPositive((dialog, which) -> {
+                    if (enableLimit.isChecked() && limitText.getText().toString().equals("")) {
+                        Toast.makeText(requireContext(), R.string.invalid_last_added_limit,
+                                Toast.LENGTH_SHORT).show();
+                    } else {
+                        PreferenceUtil.getInstance(requireContext()).setLastAddedItemShowLimitEnable
+                                (enableLimit.isChecked());
+                        PreferenceUtil.getInstance(requireContext()).setLastAddedItemShowLimit(
+                                toIntOrDefault(limitText.getText().toString(), 100));
+                        dismiss();
+                    }
+                })
+                .onNegative((dialog, which) -> dismiss())
+                .build();
+    }
+
+    public int toIntOrDefault(String s, int d) {
+        try {
+            return Integer.parseInt(s);
+        } catch (NumberFormatException e) {
+            return d;
+        }
+    }
+}

--- a/app/src/main/java/com/kabouzeid/gramophone/ui/activities/SettingsActivity.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/ui/activities/SettingsActivity.java
@@ -31,6 +31,8 @@ import com.kabouzeid.gramophone.appshortcuts.DynamicShortcutManager;
 import com.kabouzeid.gramophone.misc.NonProAllowedColors;
 import com.kabouzeid.gramophone.preferences.BlacklistPreference;
 import com.kabouzeid.gramophone.preferences.BlacklistPreferenceDialog;
+import com.kabouzeid.gramophone.preferences.LastAddedLimitPreference;
+import com.kabouzeid.gramophone.preferences.LastAddedLimitPreferenceDialog;
 import com.kabouzeid.gramophone.preferences.LibraryPreference;
 import com.kabouzeid.gramophone.preferences.LibraryPreferenceDialog;
 import com.kabouzeid.gramophone.preferences.NowPlayingScreenPreference;
@@ -170,6 +172,8 @@ public class SettingsActivity extends AbsBaseActivity implements ColorChooserDia
                 return BlacklistPreferenceDialog.newInstance();
             } else if (preference instanceof LibraryPreference) {
                 return LibraryPreferenceDialog.newInstance();
+            } else if (preference instanceof LastAddedLimitPreference) {
+                return LastAddedLimitPreferenceDialog.newInstance();
             }
             return super.onCreatePreferenceDialog(preference);
         }

--- a/app/src/main/java/com/kabouzeid/gramophone/util/PreferenceUtil.java
+++ b/app/src/main/java/com/kabouzeid/gramophone/util/PreferenceUtil.java
@@ -87,6 +87,9 @@ public final class PreferenceUtil {
 
     public static final String LIBRARY_CATEGORIES = "library_categories";
 
+    public static final String LAST_ADDED_ITEMS_LIMIT = "last_added_show_limit";
+    public static final String LAST_ADDED_ITEMS_LIMIT_ENABLE = "last_added_show_limit_enable";
+
     private static final String REMEMBER_SHUFFLE = "remember_shuffle";
 
     private static PreferenceUtil sInstance;
@@ -534,5 +537,21 @@ public final class PreferenceUtil {
         defaultCategoryInfos.add(new CategoryInfo(CategoryInfo.Category.GENRES, true));
         defaultCategoryInfos.add(new CategoryInfo(CategoryInfo.Category.PLAYLISTS, true));
         return defaultCategoryInfos;
+    }
+
+    public boolean isLastAddedItemShowLimitEnable() {
+        return mPreferences.getBoolean(LAST_ADDED_ITEMS_LIMIT_ENABLE, false);
+    }
+
+    public void setLastAddedItemShowLimitEnable(boolean enable) {
+        mPreferences.edit().putBoolean(LAST_ADDED_ITEMS_LIMIT_ENABLE, enable).apply();
+    }
+
+    public int getLastAddedItemShowLimit() {
+        return mPreferences.getInt(LAST_ADDED_ITEMS_LIMIT, 100);
+    }
+
+    public void setLastAddedItemShowLimit(int limit) {
+        mPreferences.edit().putInt(LAST_ADDED_ITEMS_LIMIT, limit).apply();
     }
 }

--- a/app/src/main/res/layout/preference_dailog_last_added_limit.xml
+++ b/app/src/main/res/layout/preference_dailog_last_added_limit.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingHorizontal="24dp"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingBottom="12dp" >
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/enable" />
+
+        <Space
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1" />
+
+        <com.google.android.material.switchmaterial.SwitchMaterial
+            android:id="@+id/last_added_limit_switch"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1" />
+    </LinearLayout>
+
+    <com.google.android.material.textfield.TextInputEditText
+        android:id="@+id/last_added_limit_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:inputType="number"
+        android:paddingVertical="12dp"
+        android:enabled="false" />
+</LinearLayout>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -304,6 +304,6 @@
     <string name="dialog_ringtone_message">السماح لـphonograph بتعديل إعدادات الصوت</string>
     <string name="last_added_items_show_limit">الحد لعرض العناصر المضافة الأخيرة</string>
     <string name="enable">ممكن</string>
-    <string name="last_added_items_show_limit_summery">صيفي</string>
-    <string name="invalid_last_added_limit">خطأ</string>
+    <string name="last_added_items_show_limit_summery">واضاف التشغيل آخر تظهر الأغاني تقتصر فقط</string>
+    <string name="invalid_last_added_limit">الرجاء إدخال رقم</string>
 </resources>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -302,4 +302,8 @@
     <string name="finish_current_music_sleep_timer">إكمال آخر أغنية</string>
     <string name="dialog_ringtone_title">تعيين كنغمة الرنين</string>
     <string name="dialog_ringtone_message">السماح لـphonograph بتعديل إعدادات الصوت</string>
+    <string name="last_added_items_show_limit">الحد لعرض العناصر المضافة الأخيرة</string>
+    <string name="enable">ممكن</string>
+    <string name="last_added_items_show_limit_summery">صيفي</string>
+    <string name="invalid_last_added_limit">خطأ</string>
 </resources>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -232,6 +232,6 @@
     <string name="playlist_is_empty">Плейлистът е празен</string>
     <string name="last_added_items_show_limit">Ограничение за показване на последно добавени елементи</string>
     <string name="enable">активиране</string>
-    <string name="last_added_items_show_limit_summery">летен</string>
-    <string name="invalid_last_added_limit">грешка</string>
+    <string name="last_added_items_show_limit_summery">Последно добавени плейлист ще показва само ограничени песни</string>
+    <string name="invalid_last_added_limit">Моля въведете номер</string>
 </resources>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -230,4 +230,8 @@
     <string name="app_shortcut_top_tracks_short">Най - често слушани</string>
     <string name="app_shortcut_last_added_short">Последно_добавени</string>
     <string name="playlist_is_empty">Плейлистът е празен</string>
+    <string name="last_added_items_show_limit">Ограничение за показване на последно добавени елементи</string>
+    <string name="enable">активиране</string>
+    <string name="last_added_items_show_limit_summery">летен</string>
+    <string name="invalid_last_added_limit">грешка</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -302,4 +302,8 @@
     <string name="finish_current_music_sleep_timer">Dokončit poslední skladbu</string>
     <string name="dialog_ringtone_title">Nastavit vyzváněcí tón</string>
     <string name="dialog_ringtone_message">Povolit aplikaci Phonograph měnit nastavení zvuku</string>
+    <string name="last_added_items_show_limit">Limit pro zobrazení naposledy přidaných položek</string>
+    <string name="enable">umožnit</string>
+    <string name="last_added_items_show_limit_summery">letní</string>
+    <string name="invalid_last_added_limit">chyba</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -304,6 +304,6 @@
     <string name="dialog_ringtone_message">Povolit aplikaci Phonograph měnit nastavení zvuku</string>
     <string name="last_added_items_show_limit">Limit pro zobrazení naposledy přidaných položek</string>
     <string name="enable">umožnit</string>
-    <string name="last_added_items_show_limit_summery">letní</string>
-    <string name="invalid_last_added_limit">chyba</string>
+    <string name="last_added_items_show_limit_summery">Poslední přidané playlist se zobrazí pouze omezené písně</string>
+    <string name="invalid_last_added_limit">Zadejte číslo</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -304,6 +304,6 @@
     <string name="dialog_ringtone_message">Phonograph erlauben, die Audioeinstellungen zu verändern</string>
     <string name="last_added_items_show_limit">Limit für die Anzeige der zuletzt hinzugefügten Elemente</string>
     <string name="enable">aktivieren</string>
-    <string name="last_added_items_show_limit_summery">sommerlich</string>
-    <string name="invalid_last_added_limit">Error</string>
+    <string name="last_added_items_show_limit_summery">Zuletzt hinzugekommen Playlist zeigt nur begrenzt Songs</string>
+    <string name="invalid_last_added_limit">Bitte gebe eine Nummer ein</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -302,4 +302,8 @@
     <string name="finish_current_music_sleep_timer">Letzten Song beenden</string>
     <string name="dialog_ringtone_title">Klingelton einstellen</string>
     <string name="dialog_ringtone_message">Phonograph erlauben, die Audioeinstellungen zu verändern</string>
+    <string name="last_added_items_show_limit">Limit für die Anzeige der zuletzt hinzugefügten Elemente</string>
+    <string name="enable">aktivieren</string>
+    <string name="last_added_items_show_limit_summery">sommerlich</string>
+    <string name="invalid_last_added_limit">Error</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -250,4 +250,8 @@
     <string name="app_shortcut_top_tracks_short">Κορυφαία Κομμάτια</string>
     <string name="app_shortcut_last_added_short">@string/last_added</string>
     <string name="playlist_is_empty">Η Λίστα αναπαραγωγής είναι κενή</string>
+    <string name="last_added_items_show_limit">Όριο για την εμφάνιση των στοιχείων που προστέθηκαν τελευταία</string>
+    <string name="enable">επιτρέπω</string>
+    <string name="last_added_items_show_limit_summery">καλοκαιρινός</string>
+    <string name="invalid_last_added_limit">λάθος</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -252,6 +252,6 @@
     <string name="playlist_is_empty">Η Λίστα αναπαραγωγής είναι κενή</string>
     <string name="last_added_items_show_limit">Όριο για την εμφάνιση των στοιχείων που προστέθηκαν τελευταία</string>
     <string name="enable">επιτρέπω</string>
-    <string name="last_added_items_show_limit_summery">καλοκαιρινός</string>
-    <string name="invalid_last_added_limit">λάθος</string>
+    <string name="last_added_items_show_limit_summery">Πρόσφατες playlist θα δείξει μόνο περιορισμένη τραγούδια</string>
+    <string name="invalid_last_added_limit">Παρακαλώ εισάγετε έναν αριθμό</string>
 </resources>

--- a/app/src/main/res/values-en-rCA/strings.xml
+++ b/app/src/main/res/values-en-rCA/strings.xml
@@ -275,6 +275,6 @@
     <string name="set_artist_image">Set artist image</string>
     <string name="last_added_items_show_limit">Limit for showing last added items</string>
     <string name="enable">Enable</string>
-    <string name="last_added_items_show_limit_summery">summery</string>
-    <string name="invalid_last_added_limit">error</string>
+    <string name="last_added_items_show_limit_summery">Last Added playlist will show only limited songs</string>
+    <string name="invalid_last_added_limit">Please enter a number</string>
 </resources>

--- a/app/src/main/res/values-en-rCA/strings.xml
+++ b/app/src/main/res/values-en-rCA/strings.xml
@@ -273,4 +273,8 @@
     <string name="pref_summary_blacklist">The content of blacklisted folders is hidden from your library</string>
     <string name="reset_artist_image">Reset artist image</string>
     <string name="set_artist_image">Set artist image</string>
+    <string name="last_added_items_show_limit">Limit for showing last added items</string>
+    <string name="enable">Enable</string>
+    <string name="last_added_items_show_limit_summery">summery</string>
+    <string name="invalid_last_added_limit">error</string>
 </resources>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -304,6 +304,6 @@
     <string name="dialog_ringtone_message">Allow phonograph to modify audio settings</string>
     <string name="last_added_items_show_limit">Limit for showing last added items</string>
     <string name="enable">Enable</string>
-    <string name="last_added_items_show_limit_summery">summery</string>
-    <string name="invalid_last_added_limit">error</string>
+    <string name="last_added_items_show_limit_summery">Last Added playlist will show only limited songs</string>
+    <string name="invalid_last_added_limit">Please enter a number</string>
 </resources>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -302,4 +302,8 @@
     <string name="finish_current_music_sleep_timer">Finish last song</string>
     <string name="dialog_ringtone_title">Set ringtone</string>
     <string name="dialog_ringtone_message">Allow phonograph to modify audio settings</string>
+    <string name="last_added_items_show_limit">Limit for showing last added items</string>
+    <string name="enable">Enable</string>
+    <string name="last_added_items_show_limit_summery">summery</string>
+    <string name="invalid_last_added_limit">error</string>
 </resources>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -303,6 +303,6 @@ El contenido de las carpetas de la lista negra está oculto en tu biblioteca"</s
     <string name="finish_current_music_sleep_timer">Terminar la última canción</string>
     <string name="last_added_items_show_limit">Límite para mostrar los últimos elementos agregados</string>
     <string name="enable">permitir</string>
-    <string name="last_added_items_show_limit_summery">veraniego</string>
-    <string name="invalid_last_added_limit">error</string>
+    <string name="last_added_items_show_limit_summery">Última Agregado lista de reproducción mostrará canciones limitados</string>
+    <string name="invalid_last_added_limit">Por favor, introduzca un número</string>
 </resources>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -301,4 +301,8 @@ El contenido de las carpetas de la lista negra está oculto en tu biblioteca"</s
     <string name="sort_order_album">Álbum</string>
     <string name="sort_order_year">Año</string>
     <string name="finish_current_music_sleep_timer">Terminar la última canción</string>
+    <string name="last_added_items_show_limit">Límite para mostrar los últimos elementos agregados</string>
+    <string name="enable">permitir</string>
+    <string name="last_added_items_show_limit_summery">veraniego</string>
+    <string name="invalid_last_added_limit">error</string>
 </resources>

--- a/app/src/main/res/values-es-rUS/strings.xml
+++ b/app/src/main/res/values-es-rUS/strings.xml
@@ -296,6 +296,6 @@
     <string name="sort_order_year">Año</string>
     <string name="last_added_items_show_limit">Límite para mostrar los últimos elementos agregados</string>
     <string name="enable">permitir</string>
-    <string name="last_added_items_show_limit_summery">veraniego</string>
-    <string name="invalid_last_added_limit">error</string>
+    <string name="last_added_items_show_limit_summery">Última Agregado lista de reproducción mostrará canciones limitados</string>
+    <string name="invalid_last_added_limit">Por favor, introduzca un número</string>
 </resources>

--- a/app/src/main/res/values-es-rUS/strings.xml
+++ b/app/src/main/res/values-es-rUS/strings.xml
@@ -294,4 +294,8 @@
     <string name="sort_order_artist">Artista</string>
     <string name="sort_order_album">Álbum</string>
     <string name="sort_order_year">Año</string>
+    <string name="last_added_items_show_limit">Límite para mostrar los últimos elementos agregados</string>
+    <string name="enable">permitir</string>
+    <string name="last_added_items_show_limit_summery">veraniego</string>
+    <string name="invalid_last_added_limit">error</string>
 </resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -300,4 +300,8 @@
     <string name="sort_order_album">Albumi</string>
     <string name="sort_order_year">Vuosi</string>
     <string name="finish_current_music_sleep_timer">Lopeta viimeinen kappale</string>
+    <string name="last_added_items_show_limit">Rajoitus viimeksi lisättyjen tuotteiden näyttämiselle</string>
+    <string name="enable">activer</string>
+    <string name="last_added_items_show_limit_summery">kesäinen</string>
+    <string name="invalid_last_added_limit">virhe</string>
 </resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -302,6 +302,6 @@
     <string name="finish_current_music_sleep_timer">Lopeta viimeinen kappale</string>
     <string name="last_added_items_show_limit">Rajoitus viimeksi lisättyjen tuotteiden näyttämiselle</string>
     <string name="enable">activer</string>
-    <string name="last_added_items_show_limit_summery">kesäinen</string>
-    <string name="invalid_last_added_limit">virhe</string>
+    <string name="last_added_items_show_limit_summery">Viimeksi lisätyt soittolista näkyy vain vähän kappaleita</string>
+    <string name="invalid_last_added_limit">Anna numero</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -304,6 +304,6 @@
     <string name="dialog_ringtone_message">Autoriser Phonograph à modifier les paramètres audio</string>
     <string name="last_added_items_show_limit">Limite d\'affichage des derniers éléments ajoutés</string>
     <string name="enable">activer</string>
-    <string name="last_added_items_show_limit_summery">d\'été</string>
-    <string name="invalid_last_added_limit">Erreur</string>
+    <string name="last_added_items_show_limit_summery">playlist Dernières ajoutées affichera des chansons seulement limitées</string>
+    <string name="invalid_last_added_limit">S\'il vous plaît entrer un numéro</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -302,4 +302,8 @@
     <string name="finish_current_music_sleep_timer">Terminer le dernier titre</string>
     <string name="dialog_ringtone_title">Définir la sonnerie</string>
     <string name="dialog_ringtone_message">Autoriser Phonograph à modifier les paramètres audio</string>
+    <string name="last_added_items_show_limit">Limite d\'affichage des derniers éléments ajoutés</string>
+    <string name="enable">activer</string>
+    <string name="last_added_items_show_limit_summery">d\'été</string>
+    <string name="invalid_last_added_limit">Erreur</string>
 </resources>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -300,4 +300,8 @@
     <string name="sort_order_album">אלבום</string>
     <string name="sort_order_year">שנה</string>
     <string name="finish_current_music_sleep_timer">סיים את השיר האחרון</string>
+    <string name="last_added_items_show_limit">מגבלה להצגת פריטים שנוספו לאחרונה</string>
+    <string name="enable">לְאַפשֵׁר</string>
+    <string name="last_added_items_show_limit_summery">קֵיצִי</string>
+    <string name="invalid_last_added_limit">שְׁגִיאָה</string>
 </resources>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -302,6 +302,6 @@
     <string name="finish_current_music_sleep_timer">סיים את השיר האחרון</string>
     <string name="last_added_items_show_limit">מגבלה להצגת פריטים שנוספו לאחרונה</string>
     <string name="enable">לְאַפשֵׁר</string>
-    <string name="last_added_items_show_limit_summery">קֵיצִי</string>
-    <string name="invalid_last_added_limit">שְׁגִיאָה</string>
+    <string name="last_added_items_show_limit_summery">רשימת השמעה הוסף לאחרונה נראתה רק שירים מוגבלים</string>
+    <string name="invalid_last_added_limit">בבקשה הכנס מספר</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -302,6 +302,6 @@
     <string name="finish_current_music_sleep_timer">Završi zadnju pjesmu</string>
     <string name="last_added_items_show_limit">Ograničenje za prikaz posljednjih dodanih stavki</string>
     <string name="enable">omogućiti</string>
-    <string name="last_added_items_show_limit_summery">ljetno</string>
-    <string name="invalid_last_added_limit">greška</string>
+    <string name="last_added_items_show_limit_summery">Zadnje dodano popis će se prikazati samo ograničene pjesme</string>
+    <string name="invalid_last_added_limit">Unesite broj</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -300,4 +300,8 @@
     <string name="sort_order_album">Album</string>
     <string name="sort_order_year">Godina</string>
     <string name="finish_current_music_sleep_timer">Završi zadnju pjesmu</string>
+    <string name="last_added_items_show_limit">Ograničenje za prikaz posljednjih dodanih stavki</string>
+    <string name="enable">omogućiti</string>
+    <string name="last_added_items_show_limit_summery">ljetno</string>
+    <string name="invalid_last_added_limit">greška</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -297,6 +297,6 @@
     <string name="sort_order_year">Év</string>
     <string name="last_added_items_show_limit">Korlát a legutóbb hozzáadott elemek megjelenítésére</string>
     <string name="enable">engedélyezze</string>
-    <string name="last_added_items_show_limit_summery">nyárias</string>
-    <string name="invalid_last_added_limit">hiba</string>
+    <string name="last_added_items_show_limit_summery">Utoljára feltöltött lejátszási lista megmutatja csak korlátozott dalok</string>
+    <string name="invalid_last_added_limit">Kérjük, adjon meg egy számot</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -295,4 +295,8 @@
     <string name="sort_order_artist">Előadó</string>
     <string name="sort_order_album">Album</string>
     <string name="sort_order_year">Év</string>
+    <string name="last_added_items_show_limit">Korlát a legutóbb hozzáadott elemek megjelenítésére</string>
+    <string name="enable">engedélyezze</string>
+    <string name="last_added_items_show_limit_summery">nyárias</string>
+    <string name="invalid_last_added_limit">hiba</string>
 </resources>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -304,6 +304,6 @@
     <string name="dialog_ringtone_message">Izinkan phonograph mengubah pengaturan audio</string>
     <string name="last_added_items_show_limit">Batas untuk menampilkan item terakhir ditambahkan</string>
     <string name="enable">memungkinkan</string>
-    <string name="last_added_items_show_limit_summery">untuk musim panas</string>
-    <string name="invalid_last_added_limit">kesalahan</string>
+    <string name="last_added_items_show_limit_summery">Terakhir Ditambahkan playlist akan menunjukkan lagu hanya terbatas</string>
+    <string name="invalid_last_added_limit">Masukkan nomor</string>
 </resources>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -302,4 +302,8 @@
     <string name="finish_current_music_sleep_timer">Selesaikan lagu terakhir</string>
     <string name="dialog_ringtone_title">Setel sebagai nada dering</string>
     <string name="dialog_ringtone_message">Izinkan phonograph mengubah pengaturan audio</string>
+    <string name="last_added_items_show_limit">Batas untuk menampilkan item terakhir ditambahkan</string>
+    <string name="enable">memungkinkan</string>
+    <string name="last_added_items_show_limit_summery">untuk musim panas</string>
+    <string name="invalid_last_added_limit">kesalahan</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -304,6 +304,6 @@
     <string name="dialog_ringtone_message">Izinkan phonograph mengubah pengaturan audio</string>
     <string name="last_added_items_show_limit">Batas untuk menampilkan item terakhir ditambahkan</string>
     <string name="enable">memungkinkan</string>
-    <string name="last_added_items_show_limit_summery">untuk musim panas</string>
-    <string name="invalid_last_added_limit">kesalahan</string>
+    <string name="last_added_items_show_limit_summery">Terakhir Ditambahkan playlist akan menunjukkan lagu hanya terbatas</string>
+    <string name="invalid_last_added_limit">Masukkan nomor</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -302,4 +302,8 @@
     <string name="finish_current_music_sleep_timer">Selesaikan lagu terakhir</string>
     <string name="dialog_ringtone_title">Setel sebagai nada dering</string>
     <string name="dialog_ringtone_message">Izinkan phonograph mengubah pengaturan audio</string>
+    <string name="last_added_items_show_limit">Batas untuk menampilkan item terakhir ditambahkan</string>
+    <string name="enable">memungkinkan</string>
+    <string name="last_added_items_show_limit_summery">untuk musim panas</string>
+    <string name="invalid_last_added_limit">kesalahan</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -305,6 +305,6 @@
     <string name="dialog_ringtone_message">Consenti a Phonograph di modificare le impostazioni audio</string>
     <string name="last_added_items_show_limit">Limite per la visualizzazione degli ultimi elementi aggiunti</string>
     <string name="enable">abilitare</string>
-    <string name="last_added_items_show_limit_summery">estivo</string>
-    <string name="invalid_last_added_limit">errore</string>
+    <string name="last_added_items_show_limit_summery">Ultime aggiunte playlist mostrerà canzoni limitate</string>
+    <string name="invalid_last_added_limit">Per favore inserisci un numero</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -303,4 +303,8 @@
     <string name="finish_current_music_sleep_timer">Termina l\'ultimo brano</string>
     <string name="dialog_ringtone_title">Imposta suoneria</string>
     <string name="dialog_ringtone_message">Consenti a Phonograph di modificare le impostazioni audio</string>
+    <string name="last_added_items_show_limit">Limite per la visualizzazione degli ultimi elementi aggiunti</string>
+    <string name="enable">abilitare</string>
+    <string name="last_added_items_show_limit_summery">estivo</string>
+    <string name="invalid_last_added_limit">errore</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -300,4 +300,8 @@
     <string name="sort_order_album">אלבום</string>
     <string name="sort_order_year">שנה</string>
     <string name="finish_current_music_sleep_timer">סיים את השיר האחרון</string>
+    <string name="last_added_items_show_limit">מגבלה להצגת פריטים שנוספו לאחרונה</string>
+    <string name="enable">לְאַפשֵׁר</string>
+    <string name="last_added_items_show_limit_summery">קֵיצִי</string>
+    <string name="invalid_last_added_limit">שְׁגִיאָה</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -302,6 +302,6 @@
     <string name="finish_current_music_sleep_timer">סיים את השיר האחרון</string>
     <string name="last_added_items_show_limit">מגבלה להצגת פריטים שנוספו לאחרונה</string>
     <string name="enable">לְאַפשֵׁר</string>
-    <string name="last_added_items_show_limit_summery">קֵיצִי</string>
-    <string name="invalid_last_added_limit">שְׁגִיאָה</string>
+    <string name="last_added_items_show_limit_summery">רשימת השמעה הוסף לאחרונה נראתה רק שירים מוגבלים</string>
+    <string name="invalid_last_added_limit">בבקשה הכנס מספר</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -302,4 +302,8 @@
     <string name="finish_current_music_sleep_timer">最後の曲を終える</string>
     <string name="dialog_ringtone_title">着信音の設定</string>
     <string name="dialog_ringtone_message">Phonographによるオーディオ設定の変更を許可する</string>
+    <string name="last_added_items_show_limit">最後に追加されたアイテムを表示するための制限</string>
+    <string name="enable">有効にする</string>
+    <string name="last_added_items_show_limit_summery">夏らしいです</string>
+    <string name="invalid_last_added_limit">エラー</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -304,6 +304,6 @@
     <string name="dialog_ringtone_message">Phonographによるオーディオ設定の変更を許可する</string>
     <string name="last_added_items_show_limit">最後に追加されたアイテムを表示するための制限</string>
     <string name="enable">有効にする</string>
-    <string name="last_added_items_show_limit_summery">夏らしいです</string>
-    <string name="invalid_last_added_limit">エラー</string>
+    <string name="last_added_items_show_limit_summery">最後に追加されたプレイリストは、限られた曲が表示されます</string>
+    <string name="invalid_last_added_limit">番号を入力してください。</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -299,6 +299,6 @@
     <string name="sort_order_year">연도</string>
     <string name="last_added_items_show_limit">마지막으로 추가 된 항목 표시 제한</string>
     <string name="enable">활성화</string>
-    <string name="last_added_items_show_limit_summery">여름의</string>
-    <string name="invalid_last_added_limit">오류</string>
+    <string name="last_added_items_show_limit_summery">마지막으로 추가 된 재생 목록에만 제한 노래를 표시합니다</string>
+    <string name="invalid_last_added_limit">숫자를 입력하세요</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -297,4 +297,8 @@
     <string name="sort_order_artist">아티스트</string>
     <string name="sort_order_album">앨범</string>
     <string name="sort_order_year">연도</string>
+    <string name="last_added_items_show_limit">마지막으로 추가 된 항목 표시 제한</string>
+    <string name="enable">활성화</string>
+    <string name="last_added_items_show_limit_summery">여름의</string>
+    <string name="invalid_last_added_limit">오류</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -297,6 +297,6 @@
     <string name="sort_order_year">Jaar</string>
     <string name="last_added_items_show_limit">Limiet voor het tonen van laatst toegevoegde items</string>
     <string name="enable">inschakelen</string>
-    <string name="last_added_items_show_limit_summery">zomers</string>
-    <string name="invalid_last_added_limit">fout</string>
+    <string name="last_added_items_show_limit_summery">Laatst toegevoegd afspeellijst wordt slechts in beperkte mate voorkomt blijkt</string>
+    <string name="invalid_last_added_limit">Voer alstublieft een nummer in</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -295,4 +295,8 @@
     <string name="sort_order_artist">Artiest</string>
     <string name="sort_order_album">Album</string>
     <string name="sort_order_year">Jaar</string>
+    <string name="last_added_items_show_limit">Limiet voor het tonen van laatst toegevoegde items</string>
+    <string name="enable">inschakelen</string>
+    <string name="last_added_items_show_limit_summery">zomers</string>
+    <string name="invalid_last_added_limit">fout</string>
 </resources>

--- a/app/src/main/res/values-nn/strings.xml
+++ b/app/src/main/res/values-nn/strings.xml
@@ -79,4 +79,8 @@
     <string name="song">Song</string>
     <string name="search_hint">Søk i biblioteket...</string>
     <string name="new_playlist_title">Ny speleliste</string>
+    <string name="last_added_items_show_limit">Grense for visning av sist tilføyde elementer</string>
+    <string name="enable">muliggjøre</string>
+    <string name="last_added_items_show_limit_summery">sommerlig</string>
+    <string name="invalid_last_added_limit">feil</string>
 </resources>

--- a/app/src/main/res/values-nn/strings.xml
+++ b/app/src/main/res/values-nn/strings.xml
@@ -81,6 +81,6 @@
     <string name="new_playlist_title">Ny speleliste</string>
     <string name="last_added_items_show_limit">Grense for visning av sist tilføyde elementer</string>
     <string name="enable">muliggjøre</string>
-    <string name="last_added_items_show_limit_summery">sommerlig</string>
-    <string name="invalid_last_added_limit">feil</string>
+    <string name="last_added_items_show_limit_summery">Sist lagt til spilleliste viser bare begrensede sanger</string>
+    <string name="invalid_last_added_limit">Vennligst skriv inn et nummer</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -295,4 +295,8 @@
     <string name="sort_order_artist">Artysta</string>
     <string name="sort_order_album">Album</string>
     <string name="sort_order_year">Rok</string>
+    <string name="last_added_items_show_limit">Limit wyświetlania ostatnio dodanych elementów</string>
+    <string name="enable">włączyć</string>
+    <string name="last_added_items_show_limit_summery">letni</string>
+    <string name="invalid_last_added_limit">błąd</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -297,6 +297,6 @@
     <string name="sort_order_year">Rok</string>
     <string name="last_added_items_show_limit">Limit wyświetlania ostatnio dodanych elementów</string>
     <string name="enable">włączyć</string>
-    <string name="last_added_items_show_limit_summery">letni</string>
-    <string name="invalid_last_added_limit">błąd</string>
+    <string name="last_added_items_show_limit_summery">Ostatnio dodane playlist pokaże tylko ograniczone piosenki</string>
+    <string name="invalid_last_added_limit">Proszę wpisać numer</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -304,6 +304,6 @@
     <string name="dialog_ringtone_message">Permitir que o Phonograph modifique as configurações de áudio</string>
     <string name="last_added_items_show_limit">Limite para mostrar itens de última adicionadas</string>
     <string name="enable">habilitar</string>
-    <string name="last_added_items_show_limit_summery">verão</string>
-    <string name="invalid_last_added_limit">erro</string>
+    <string name="last_added_items_show_limit_summery">Últimas Adicionadas lista irá mostrar canções limitado apenas</string>
+    <string name="invalid_last_added_limit">Por favor, coloque um numero</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -302,4 +302,8 @@
     <string name="finish_current_music_sleep_timer">Finalizar última música</string>
     <string name="dialog_ringtone_title">Definir toque</string>
     <string name="dialog_ringtone_message">Permitir que o Phonograph modifique as configurações de áudio</string>
+    <string name="last_added_items_show_limit">Limite para mostrar itens de última adicionadas</string>
+    <string name="enable">habilitar</string>
+    <string name="last_added_items_show_limit_summery">verão</string>
+    <string name="invalid_last_added_limit">erro</string>
 </resources>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -215,4 +215,8 @@
     <string name="bug_report_failed_unknown">Ocorreu um erro inesperado. Por favor contacte o desenvolvedor da aplicação.</string>
     <string name="your_account_data_is_only_used_for_authentication">A sua informação da conta é apenas usada para a autenticação.</string>
     <string name="you_will_be_forwarded_to_the_issue_tracker_website">Vai ser reencaminhado para o site do rastreador de problemas.</string>
+    <string name="last_added_items_show_limit">Limite para mostrar itens de última adicionadas</string>
+    <string name="enable">habilitar</string>
+    <string name="last_added_items_show_limit_summery">verão</string>
+    <string name="invalid_last_added_limit">erro</string>
 </resources>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -217,6 +217,6 @@
     <string name="you_will_be_forwarded_to_the_issue_tracker_website">Vai ser reencaminhado para o site do rastreador de problemas.</string>
     <string name="last_added_items_show_limit">Limite para mostrar itens de última adicionadas</string>
     <string name="enable">habilitar</string>
-    <string name="last_added_items_show_limit_summery">verão</string>
-    <string name="invalid_last_added_limit">erro</string>
+    <string name="last_added_items_show_limit_summery">Últimas Adicionadas lista irá mostrar canções limitado apenas</string>
+    <string name="invalid_last_added_limit">Por favor, coloque um numero</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -297,6 +297,6 @@
     <string name="sort_order_year">An</string>
     <string name="last_added_items_show_limit">Limită pentru afișarea ultimelor elemente adăugate</string>
     <string name="enable">permite</string>
-    <string name="last_added_items_show_limit_summery">estival</string>
-    <string name="invalid_last_added_limit">eroare</string>
+    <string name="last_added_items_show_limit_summery">Ultimele adaugate lista de redare va afișa doar melodiile limitate</string>
+    <string name="invalid_last_added_limit">Vă rugăm să introduceți un număr</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -295,4 +295,8 @@
     <string name="sort_order_artist">Artist</string>
     <string name="sort_order_album">Album</string>
     <string name="sort_order_year">An</string>
+    <string name="last_added_items_show_limit">Limită pentru afișarea ultimelor elemente adăugate</string>
+    <string name="enable">permite</string>
+    <string name="last_added_items_show_limit_summery">estival</string>
+    <string name="invalid_last_added_limit">eroare</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -304,6 +304,6 @@
     <string name="dialog_ringtone_message">Разрешить приложению изменять настройки аудио</string>
     <string name="last_added_items_show_limit">Лимит для показа последних добавленных элементов</string>
     <string name="enable">включить</string>
-    <string name="last_added_items_show_limit_summery">летний</string>
-    <string name="invalid_last_added_limit">ошибка</string>
+    <string name="last_added_items_show_limit_summery">плейлист Последние добавленные будут показывать только ограниченные песни</string>
+    <string name="invalid_last_added_limit">Пожалуйста, введите номер</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -302,4 +302,8 @@
     <string name="finish_current_music_sleep_timer">Последняя песня завершилась</string>
     <string name="dialog_ringtone_title">Установить рингтон</string>
     <string name="dialog_ringtone_message">Разрешить приложению изменять настройки аудио</string>
+    <string name="last_added_items_show_limit">Лимит для показа последних добавленных элементов</string>
+    <string name="enable">включить</string>
+    <string name="last_added_items_show_limit_summery">летний</string>
+    <string name="invalid_last_added_limit">ошибка</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -89,6 +89,6 @@ Vill du radera <b>%1$d</b> låtar?
     <string name="new_playlist_title">Ny spellista</string>
     <string name="last_added_items_show_limit">Gräns för visning av senast tillagda objekt</string>
     <string name="enable">Gör det möjligt</string>
-    <string name="last_added_items_show_limit_summery">sommarlik</string>
-    <string name="invalid_last_added_limit">fel</string>
+    <string name="last_added_items_show_limit_summery">Senast inlagd spellista kommer att visa endast begränsade låtar</string>
+    <string name="invalid_last_added_limit">ange ett nummer</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -87,4 +87,8 @@ Vill du radera <b>%1$d</b> låtar?
     <string name="pref_summary_colored_navigation_bar">I vilken vy navigeringslisten skall vara färgad</string>
     <string name="search_hint">Sök i ditt bibliotek ...</string>
     <string name="new_playlist_title">Ny spellista</string>
+    <string name="last_added_items_show_limit">Gräns för visning av senast tillagda objekt</string>
+    <string name="enable">Gör det möjligt</string>
+    <string name="last_added_items_show_limit_summery">sommarlik</string>
+    <string name="invalid_last_added_limit">fel</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -302,4 +302,8 @@
     <string name="finish_current_music_sleep_timer">Son şarkıyı bitir</string>
     <string name="dialog_ringtone_title">Zil sesi olarak ayarla</string>
     <string name="dialog_ringtone_message">Phonograph\'ın ses ayarlarını değiştirmesine izin ver</string>
+    <string name="last_added_items_show_limit">Son eklenen öğeleri gösterme sınırı</string>
+    <string name="enable">etkinleştirme</string>
+    <string name="last_added_items_show_limit_summery">yazlık</string>
+    <string name="invalid_last_added_limit">hata</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -304,6 +304,6 @@
     <string name="dialog_ringtone_message">Phonograph\'ın ses ayarlarını değiştirmesine izin ver</string>
     <string name="last_added_items_show_limit">Son eklenen öğeleri gösterme sınırı</string>
     <string name="enable">etkinleştirme</string>
-    <string name="last_added_items_show_limit_summery">yazlık</string>
-    <string name="invalid_last_added_limit">hata</string>
+    <string name="last_added_items_show_limit_summery">Son Eklenen çalma listesi sadece sınırlı şarkıyı gösterir</string>
+    <string name="invalid_last_added_limit">Lütfen bir numara giriniz</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -284,6 +284,6 @@
     <string name="sort_order_year">Рік</string>
     <string name="last_added_items_show_limit">Обмеження для показу останніх доданих елементів</string>
     <string name="enable">увімкнути</string>
-    <string name="last_added_items_show_limit_summery">річний</string>
-    <string name="invalid_last_added_limit">помилка</string>
+    <string name="last_added_items_show_limit_summery">плейлист Останні додані будуть показувати тільки обмежені пісні</string>
+    <string name="invalid_last_added_limit">Будь ласка, введіть номер</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -282,4 +282,8 @@
     <string name="sort_order_artist">Виконавець</string>
     <string name="sort_order_album">Альбом</string>
     <string name="sort_order_year">Рік</string>
+    <string name="last_added_items_show_limit">Обмеження для показу останніх доданих елементів</string>
+    <string name="enable">увімкнути</string>
+    <string name="last_added_items_show_limit_summery">річний</string>
+    <string name="invalid_last_added_limit">помилка</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -302,4 +302,8 @@
     <string name="finish_current_music_sleep_timer">Phát hết bài cuối</string>
     <string name="dialog_ringtone_title">Cài nhạc chuông</string>
     <string name="dialog_ringtone_message">Cho phép Phonograph thay đổi cài đặt âm thanh</string>
+    <string name="last_added_items_show_limit">Giới hạn hiển thị các mục được thêm vào lần cuối</string>
+    <string name="enable">kích hoạt</string>
+    <string name="last_added_items_show_limit_summery">thuộc về mùa hạ</string>
+    <string name="invalid_last_added_limit">lỗi</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -304,6 +304,6 @@
     <string name="dialog_ringtone_message">Cho phép Phonograph thay đổi cài đặt âm thanh</string>
     <string name="last_added_items_show_limit">Giới hạn hiển thị các mục được thêm vào lần cuối</string>
     <string name="enable">kích hoạt</string>
-    <string name="last_added_items_show_limit_summery">thuộc về mùa hạ</string>
-    <string name="invalid_last_added_limit">lỗi</string>
+    <string name="last_added_items_show_limit_summery">Đã thêm lần cuối danh sách sẽ hiển thị bài hát chỉ giới hạn</string>
+    <string name="invalid_last_added_limit">Vui lòng nhập một số</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -302,4 +302,8 @@
     <string name="finish_current_music_sleep_timer">播完最后一首</string>
     <string name="dialog_ringtone_title">设置为铃声</string>
     <string name="dialog_ringtone_message">允许 Phonograph 调整音频设定</string>
+    <string name="enable">使能夠</string>
+    <string name="last_added_items_show_limit">顯示最後添加的項的限制</string>
+    <string name="last_added_items_show_limit_summery">夏日</string>
+    <string name="invalid_last_added_limit">错误</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -304,6 +304,6 @@
     <string name="dialog_ringtone_message">允许 Phonograph 调整音频设定</string>
     <string name="enable">使能夠</string>
     <string name="last_added_items_show_limit">顯示最後添加的項的限制</string>
-    <string name="last_added_items_show_limit_summery">夏日</string>
-    <string name="invalid_last_added_limit">错误</string>
+    <string name="last_added_items_show_limit_summery">最后追加的播放列表会显示只有有限的歌曲</string>
+    <string name="invalid_last_added_limit">请输入号码</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -303,4 +303,8 @@
     <string name="finish_current_music_sleep_timer">歌曲全數播放完畢</string>
     <string name="dialog_ringtone_title">設定鈴聲</string>
     <string name="dialog_ringtone_message">允許 Phonograph 修改音訊設定</string>
+    <string name="enable">使能够</string>
+    <string name="last_added_items_show_limit">显示最后添加的项的限制</string>
+    <string name="last_added_items_show_limit_summery">夏日</string>
+    <string name="invalid_last_added_limit">错误</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -305,6 +305,6 @@
     <string name="dialog_ringtone_message">允許 Phonograph 修改音訊設定</string>
     <string name="enable">使能够</string>
     <string name="last_added_items_show_limit">显示最后添加的项的限制</string>
-    <string name="last_added_items_show_limit_summery">夏日</string>
-    <string name="invalid_last_added_limit">错误</string>
+    <string name="last_added_items_show_limit_summery">最后追加的播放列表会显示只有有限的歌曲</string>
+    <string name="invalid_last_added_limit">请输入号码</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -310,4 +310,5 @@
     <string name="finish_current_music_sleep_timer">Finish last song</string>
     <string name="dialog_ringtone_title">Set ringtone</string>
     <string name="dialog_ringtone_message">Allow phonograph to modify audio settings</string>
+    <string name="last_added_items_show_limit">Last added items show limit</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -310,7 +310,7 @@
     <string name="finish_current_music_sleep_timer">Finish last song</string>
     <string name="dialog_ringtone_title">Set ringtone</string>
     <string name="dialog_ringtone_message">Allow phonograph to modify audio settings</string>
-    <string name="last_added_items_show_limit">Last added items show limit</string>
+    <string name="last_added_items_show_limit">Limit for showing last added items</string>
     <string name="last_added_items_show_limit_summery">Summery</string>
     <string name="enable">Enable</string>
     <string name="invalid_last_added_limit">Error</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -311,7 +311,7 @@
     <string name="dialog_ringtone_title">Set ringtone</string>
     <string name="dialog_ringtone_message">Allow phonograph to modify audio settings</string>
     <string name="last_added_items_show_limit">Limit for showing last added items</string>
-    <string name="last_added_items_show_limit_summery">Summery</string>
+    <string name="last_added_items_show_limit_summery">Last Added playlist will show only limited songs</string>
     <string name="enable">Enable</string>
-    <string name="invalid_last_added_limit">Error</string>
+    <string name="invalid_last_added_limit">Please enter a number</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -311,4 +311,7 @@
     <string name="dialog_ringtone_title">Set ringtone</string>
     <string name="dialog_ringtone_message">Allow phonograph to modify audio settings</string>
     <string name="last_added_items_show_limit">Last added items show limit</string>
+    <string name="last_added_items_show_limit_summery">Summery</string>
+    <string name="enable">Enable</string>
+    <string name="invalid_last_added_limit">Error</string>
 </resources>

--- a/app/src/main/res/xml/pref_playlists.xml
+++ b/app/src/main/res/xml/pref_playlists.xml
@@ -13,6 +13,11 @@
             android:positiveButtonText="@null"
             android:title="@string/pref_title_last_added_interval" />
 
+        <com.kabouzeid.gramophone.preferences.LastAddedLimitPreference
+            app:iconSpaceReserved="false"
+            android:title="@string/last_added_items_show_limit"
+            android:summary="@string/last_added_items_show_limit_summery" />
+
     </com.kabouzeid.appthemehelper.common.prefs.supportv7.ATEPreferenceCategory>
 
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
We created a dialog preference in preference screen and get desired limit from user. User can also disable this functionality and see the last added playlist without any limits. By default, limit is _disabled_.
Below here you can see some screenshots from last added playlist when I set limit to _five_.
![Screenshot_20210514-120030_Phonograph](https://user-images.githubusercontent.com/62179268/118305386-1f501680-b4fd-11eb-98cd-ba1750e0a3c9.jpg)
